### PR TITLE
Ag3 SNP xarray dataset enhancements

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -748,6 +748,7 @@ class Ag3:
                 data_vars="minimal",
                 coords="minimal",
                 compat="override",
+                join="override",
             )
 
         # TODO apply site filters


### PR DESCRIPTION
This PR makes some enhancements to the Ag3 method which returns an xarray dataset holding data on SNP calls. 

* Rename `Ag3.snp_dataset()` to `Ag3.snp_calls()` - in future I think we'll be returning xarray datasets from other methods, and we don't want to always have to add "_dataset" to the end of every method name that does so.
* Add additional data variables `call_GQ`, `call_AD`, `call_MQ`, `variant_filter_pass_...` to the dataset.
* `Ag3.snp_calls()` now sets up it's own arrays, rather than depending on `snp_sites()` and `snp_genotypes()` - this simplifies the handling of multiple sample sets, which uses `xarray.concat()`.

Btw I decided **not** to include any sample metadata variables for the time being. May revisit that in future.

Resolves #13.