### PR TITLE
Work around memory and performance issues with xarray indexing

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -4,7 +4,13 @@ import zarr
 import dask.array as da
 import numpy as np
 import xarray
-from .util import read_gff3, unpack_gff3_attributes, SafeStore, from_zarr
+from .util import (
+    read_gff3,
+    unpack_gff3_attributes,
+    SafeStore,
+    from_zarr,
+    dask_compress_dataset,
+)
 
 
 DIM_VARIANT = "variants"
@@ -818,8 +824,9 @@ class Ag3:
 
         # apply site filters
         if site_mask is not None:
-            loc_pass = ds[f"variant_filter_pass_{site_mask}"]
-            ds = ds.isel(variants=loc_pass)
+            ds = dask_compress_dataset(
+                ds, indexer=f"variant_filter_pass_{site_mask}", dim=DIM_VARIANT
+            )
 
         return ds
 

--- a/malariagen_data/util.py
+++ b/malariagen_data/util.py
@@ -143,7 +143,8 @@ def dask_compress_dataset(ds, indexer, dim):
     xarray.Dataset
 
     """
-    indexer = ds[indexer].data
+    if isinstance(indexer, str):
+        indexer = ds[indexer].data
 
     # sanity checks
     assert isinstance(indexer, da.Array)

--- a/malariagen_data/util.py
+++ b/malariagen_data/util.py
@@ -150,6 +150,7 @@ def dask_compress_dataset(ds, indexer, dim):
     assert isinstance(indexer, da.Array)
     assert indexer.ndim == 1
     assert indexer.dtype == bool
+    assert indexer.shape[0] == ds.dims[dim]
 
     coords = dict()
     for k in ds.coords:

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -404,6 +404,8 @@ def test_snp_calls(sample_sets, contig, site_mask):
         "call_MQ",
     }
     assert expected_fields == set(ds)
+    for f in expected_fields:
+        assert isinstance(ds[f].data, da.Array)
 
     # check dimensions
     assert {"alleles", "ploidy", "samples", "variants"} == set(ds.dims)


### PR DESCRIPTION
In testing the `ag3.snp_calls()` method with site filters applied, some memory and performance issues have come up (https://github.com/pydata/xarray/issues/5054). This PR has a temporary workaround.