### PR TITLE
Optimisations: auto chunks; faster da.compress

### DIFF
--- a/malariagen_data/util.py
+++ b/malariagen_data/util.py
@@ -109,14 +109,16 @@ class SiteClass(Enum):
     INTRON_LAST = 10
 
 
-def from_zarr(z, inline_array):
+def from_zarr(z, inline_array, chunks="auto"):
     """Utility function for turning a zarr array into a dask array.
 
     N.B., dask does have it's own from_zarr() function but we roll
     our own here to get a little more control.
 
     """
-    kwargs = dict(chunks=z.chunks, fancy=False, lock=False, inline_array=inline_array)
+    if chunks == "native":
+        chunks = z.chunks
+    kwargs = dict(chunks=chunks, fancy=False, lock=False, inline_array=inline_array)
     try:
         d = da.from_array(z, **kwargs)
     except TypeError:
@@ -179,33 +181,41 @@ def _dask_compress_dataarray(a, indexer, dim):
         v = a.data
 
     else:
-        data = a.data
-
-        # sanity checks
-        assert isinstance(data, da.Array)
-        assert indexer.shape[0] == data.shape[axis]
-
         # apply the indexing operation
-        v = da.compress(indexer, data, axis=axis)
+        v = dask_compress(a.data, indexer, axis)
 
-        # need to compute chunks sizes in order to know dimension sizes;
-        # would normally do v.compute_chunk_sizes() but that is slow for
-        # multidimensional arrays, so hack something more efficient
+    return v
 
-        old_chunks = data.chunks
-        axis_old_chunks = old_chunks[axis]
-        axis_n_chunks = len(axis_old_chunks)
-        axis_new_chunks = tuple(
-            indexer.rechunk(axis_old_chunks)
-            .map_blocks(
-                lambda b: np.sum(b, keepdims=True),
-                chunks=((1,) * axis_n_chunks,),
-            )
-            .compute()
+
+def dask_compress(data, indexer, axis):
+
+    # sanity checks
+    assert isinstance(data, da.Array)
+    assert isinstance(indexer, da.Array)
+    assert isinstance(axis, int)
+    assert indexer.shape[0] == data.shape[axis]
+
+    # apply the indexing operation
+    v = da.compress(indexer, data, axis=axis)
+
+    # need to compute chunks sizes in order to know dimension sizes;
+    # would normally do v.compute_chunk_sizes() but that is slow for
+    # multidimensional arrays, so hack something more efficient
+
+    old_chunks = data.chunks
+    axis_old_chunks = old_chunks[axis]
+    axis_n_chunks = len(axis_old_chunks)
+    axis_new_chunks = tuple(
+        indexer.rechunk(axis_old_chunks)
+        .map_blocks(
+            lambda b: np.sum(b, keepdims=True),
+            chunks=((1,) * axis_n_chunks,),
         )
-        new_chunks = tuple(
-            [axis_new_chunks if i == axis else c for i, c in enumerate(old_chunks)]
-        )
-        v._chunks = new_chunks
+        .compute()
+    )
+    new_chunks = tuple(
+        [axis_new_chunks if i == axis else c for i, c in enumerate(old_chunks)]
+    )
+    v._chunks = new_chunks
 
     return v

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -169,7 +169,8 @@ def test_site_filters():
             assert bool == filter_pass.dtype
 
 
-def test_snp_sites():
+@pytest.mark.parametrize("chunks", ["auto", "native"])
+def test_snp_sites(chunks):
 
     ag3 = Ag3(gcs_url)
 
@@ -181,7 +182,7 @@ def test_snp_sites():
 
     # check access as dask arrays
     for contig in contigs:
-        pos, ref, alt = ag3.snp_sites(contig=contig)
+        pos, ref, alt = ag3.snp_sites(contig=contig, chunks=chunks)
         assert isinstance(pos, da.Array)
         assert 1 == pos.ndim
         assert "i4" == pos.dtype
@@ -194,14 +195,16 @@ def test_snp_sites():
         assert pos.shape[0] == ref.shape[0] == alt.shape[0]
 
     # specific field
-    pos = ag3.snp_sites(contig="3R", field="POS")
+    pos = ag3.snp_sites(contig="3R", field="POS", chunks=chunks)
     assert isinstance(pos, da.Array)
     assert 1 == pos.ndim
     assert "i4" == pos.dtype
 
     # apply site mask
     filter_pass = ag3.site_filters(contig="X", mask="gamb_colu_arab").compute()
-    pos_pass = ag3.snp_sites(contig="X", field="POS", site_mask="gamb_colu_arab")
+    pos_pass = ag3.snp_sites(
+        contig="X", field="POS", site_mask="gamb_colu_arab", chunks=chunks
+    )
     assert isinstance(pos_pass, da.Array)
     assert 1 == pos_pass.ndim
     assert "i4" == pos_pass.dtype
@@ -212,7 +215,8 @@ def test_snp_sites():
         assert np.count_nonzero(filter_pass) == d.shape[0]
 
 
-def test_snp_genotypes():
+@pytest.mark.parametrize("chunks", ["auto", "native"])
+def test_snp_genotypes(chunks):
 
     ag3 = Ag3(gcs_url)
 
@@ -233,26 +237,28 @@ def test_snp_genotypes():
     for sample_sets in sample_setss:
         df_samples = ag3.sample_metadata(sample_sets=sample_sets, species_calls=None)
         for contig in contigs:
-            gt = ag3.snp_genotypes(contig=contig, sample_sets=sample_sets)
+            gt = ag3.snp_genotypes(
+                contig=contig, sample_sets=sample_sets, chunks=chunks
+            )
             assert isinstance(gt, da.Array)
             assert 3 == gt.ndim
             assert "i1" == gt.dtype
             assert len(df_samples) == gt.shape[1]
 
     # specific fields
-    x = ag3.snp_genotypes(contig="X", field="GT")
+    x = ag3.snp_genotypes(contig="X", field="GT", chunks=chunks)
     assert isinstance(x, da.Array)
     assert 3 == x.ndim
     assert "i1" == x.dtype
-    x = ag3.snp_genotypes(contig="X", field="GQ")
+    x = ag3.snp_genotypes(contig="X", field="GQ", chunks=chunks)
     assert isinstance(x, da.Array)
     assert 2 == x.ndim
     assert "i2" == x.dtype
-    x = ag3.snp_genotypes(contig="X", field="MQ")
+    x = ag3.snp_genotypes(contig="X", field="MQ", chunks=chunks)
     assert isinstance(x, da.Array)
     assert 2 == x.ndim
     assert "i2" == x.dtype
-    x = ag3.snp_genotypes(contig="X", field="AD")
+    x = ag3.snp_genotypes(contig="X", field="AD", chunks=chunks)
     assert isinstance(x, da.Array)
     assert 3 == x.ndim
     assert "i2" == x.dtype
@@ -260,7 +266,7 @@ def test_snp_genotypes():
     # site mask
     filter_pass = ag3.site_filters(contig="X", mask="gamb_colu_arab").compute()
     df_samples = ag3.sample_metadata()
-    gt_pass = ag3.snp_genotypes(contig="X", site_mask="gamb_colu_arab")
+    gt_pass = ag3.snp_genotypes(contig="X", site_mask="gamb_colu_arab", chunks=chunks)
     assert isinstance(gt_pass, da.Array)
     assert 3 == gt_pass.ndim
     assert "i1" == gt_pass.dtype


### PR DESCRIPTION
* Add support for a `chunks` argument which defaults to `auto` allowing dask to choose chunk sizes larger than the native zarr size. This speeds-up data retrieval from colab by a factor of ~2.
* Manually compute chunk sizes after dask.array.compress operations.