### PR TITLE
Ag3 snp effects updates

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -668,9 +668,9 @@ class Ag3:
         df_in["position"] = np.asarray(pos[loc])
         df_in["ref_allele"] = [q.tobytes().decode() for q in np.asarray(ref)]
         # bytes within lists within lists...
-        df_in["alt_alleles"] = [list(q.tobytes().decode()) for q in list(alt)]
+        df_in["alt_allele"] = [list(q.tobytes().decode()) for q in list(alt)]
         # explode the alt alleles into their own rows
-        df_effects = df_in.explode("alt_alleles").reset_index(drop=True)
+        df_effects = df_in.explode("alt_allele").reset_index(drop=True)
 
         # then, iterate over rows of the dataframe, calling get_effects()
         # for each row, and using that to build additional columns effect,
@@ -690,7 +690,7 @@ class Ag3:
                 chrom=contig,
                 pos=row.position,
                 ref=row.ref_allele,
-                alt=row.alt_alleles,
+                alt=row.alt_allele,
                 transcript_ids=[transcript],
             ):
                 leffect.append(effect.effect)

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -631,23 +631,8 @@ class Ag3:
 
         return is_accessible
 
-    def snp_single_effect(self, chrom, pos, ref, alt, transcript):
-        # TODO remove seqid here and from veff constructor
-        if self._cache_annotator is None:
-            self._cache_annotator = veff.Annotator(
-                genome=self.open_genome(), geneset=self.geneset()
-            )
-        ann = self._cache_annotator
-
-        for effect in ann.get_effects(chrom=chrom, pos=pos, ref=ref, alt=alt,
-                                      transcript_ids=transcript):
-            return effect
-
-
-
 
     def snp_effects(self, transcript, site_mask):
-
         # take an AGAP transcript ID and get meta data from the gff using veff
         # first time sets up and caches ann object
         if self._cache_annotator is None:

--- a/malariagen_data/veff.py
+++ b/malariagen_data/veff.py
@@ -935,11 +935,10 @@ def _get_within_intron_effect(annotator, base_effect, intron, exons):
         # SNPs
 
         if intron_min_dist <= 2:
-
             # splice site variation
             effect = base_effect._replace(effect="SPLICE_CORE", impact="HIGH")
 
-        if intron_min_dist <= 7:
+        elif intron_min_dist <= 7:
 
             # splice site variation
             effect = base_effect._replace(effect="SPLICE_REGION", impact="MODERATE")

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -479,15 +479,6 @@ def test_snp_calls(sample_sets, contig, site_mask):
     assert isinstance(d2, xarray.DataArray)
 
 
-def test_snp_single_effect():
-    ag3 = setup_ag3()
-    gste2 = 'AGAP009194-RA'
-    # no effect
-    e = ag3.snp_single_effect('3R', pos=28597652, ref='G', alt='A', transcript=[gste2])
-    assert isinstance(e, malariagen_data.veff.VariantEffect)
-    assert e.effect == 'THREE_PRIME_UTR'
-
-
 def test_snp_effects():
     ag3 = setup_ag3()
     gste2 = "AGAP009194-RA"
@@ -503,81 +494,85 @@ def test_snp_effects():
                        "ref_aa",
                        "alt_aa",
                        "aa_change"
-    ]
+                       ]
 
-    # df = ag3.snp_effects(gste2, site_mask)
-    # assert isinstance(df, pandas.DataFrame)
-    # assert expected_fields == df.columns.tolist()
-    #
-    # # reverse strand gene
-    # assert df.shape == (2838, 11)
-    # # check first, second, third codon position non-syn
-    # assert df.iloc[1454].aa_change == "I114L"
-    # assert df.iloc[1446].aa_change == "I114M"
-    # # while we are here, check all columns for a position
-    # assert df.iloc[1451].position == 28598166
-    # assert df.iloc[1451].ref_allele == "A"
-    # assert df.iloc[1451].alt_alleles == "G"
-    # assert df.iloc[1451].effect == "NON_SYNONYMOUS_CODING"
-    # assert df.iloc[1451].impact == "MODERATE"
-    # assert df.iloc[1451].ref_codon == "aTt"
-    # assert df.iloc[1451].alt_codon == "aCt"
-    # assert df.iloc[1451].aa_pos == 114
-    # assert df.iloc[1451].ref_aa == "I"
-    # assert df.iloc[1451].alt_aa == "T"
-    # assert df.iloc[1451].aa_change == "I114T"
-    # # check syn
-    # assert df.iloc[1447].aa_change == 'I114I'
-    # # check intronic
-    # assert df.iloc[1197].effect == 'INTRONIC'
-    # # check 5' utr
-    # assert df.iloc[2661].effect == 'FIVE_PRIME_UTR'
-    # # check 3' utr
-    # assert df.iloc[0].effect == 'THREE_PRIME_UTR'
-    #
-    # # test forward strand gene gste6
-    # gste6 = "AGAP009196-RA"
-    # df = ag3.snp_effects(gste6, site_mask)
-    # assert isinstance(df, pandas.DataFrame)
-    # assert expected_fields == df.columns.tolist()
-    # assert df.shape == (2829, 11)
-    #
-    # # check first, second, third codon position non-syn
-    # assert df.iloc[701].aa_change == "E35*"
-    # assert df.iloc[703].aa_change == "E35V"
-    # # while we are here, check all columns for a position
-    # assert df.iloc[706].position == 28600605
-    # assert df.iloc[706].ref_allele == "G"
-    # assert df.iloc[706].alt_alleles == "C"
-    # assert df.iloc[706].effect == "NON_SYNONYMOUS_CODING"
-    # assert df.iloc[706].impact == "MODERATE"
-    # assert df.iloc[706].ref_codon == "gaG"
-    # assert df.iloc[706].alt_codon == "gaC"
-    # assert df.iloc[706].aa_pos == 35
-    # assert df.iloc[706].ref_aa == "E"
-    # assert df.iloc[706].alt_aa == "D"
-    # assert df.iloc[706].aa_change == "E35D"
-    # # check syn
-    # assert df.iloc[705].aa_change == 'E35E'
-    # # check intronic
-    # assert df.iloc[900].effect == 'INTRONIC'
-    # # check 5' utr
-    # assert df.iloc[0].effect == 'FIVE_PRIME_UTR'
-    # # check 3' utr
-    # assert df.iloc[2828].effect == 'THREE_PRIME_UTR'
+    df = ag3.snp_effects(gste2, site_mask)
+    assert isinstance(df, pandas.DataFrame)
+    assert expected_fields == df.columns.tolist()
 
-    #check 5' utr intron
-#     utrintron5 = "AGAP004679-RB"
-#     df = ag3.snp_effects(utrintron5, site_mask)
-#     assert isinstance(df, pandas.DataFrame)
-#     assert expected_fields == df.columns.tolist()
-#     assert df.shape == (7686, 11)
-#     assert df.loc[180].effect == 'SPLICE_REGION'
+    # reverse strand gene
+    assert df.shape == (2838, 11)
+    # check first, second, third codon position non-syn
+    assert df.iloc[1454].aa_change == "I114L"
+    assert df.iloc[1446].aa_change == "I114M"
+    # while we are here, check all columns for a position
+    assert df.iloc[1451].position == 28598166
+    assert df.iloc[1451].ref_allele == "A"
+    assert df.iloc[1451].alt_alleles == "G"
+    assert df.iloc[1451].effect == "NON_SYNONYMOUS_CODING"
+    assert df.iloc[1451].impact == "MODERATE"
+    assert df.iloc[1451].ref_codon == "aTt"
+    assert df.iloc[1451].alt_codon == "aCt"
+    assert df.iloc[1451].aa_pos == 114
+    assert df.iloc[1451].ref_aa == "I"
+    assert df.iloc[1451].alt_aa == "T"
+    assert df.iloc[1451].aa_change == "I114T"
+    # check syn
+    assert df.iloc[1447].aa_change == 'I114I'
+    # check intronic
+    assert df.iloc[1197].effect == 'INTRONIC'
+    # check 5' utr
+    assert df.iloc[2661].effect == 'FIVE_PRIME_UTR'
+    # check 3' utr
+    assert df.iloc[0].effect == 'THREE_PRIME_UTR'
+
+    # test forward strand gene gste6
+    gste6 = "AGAP009196-RA"
+    df = ag3.snp_effects(gste6, site_mask)
+    assert isinstance(df, pandas.DataFrame)
+    assert expected_fields == df.columns.tolist()
+    assert df.shape == (2829, 11)
+
+    # check first, second, third codon position non-syn
+    assert df.iloc[701].aa_change == "E35*"
+    assert df.iloc[703].aa_change == "E35V"
+    # while we are here, check all columns for a position
+    assert df.iloc[706].position == 28600605
+    assert df.iloc[706].ref_allele == "G"
+    assert df.iloc[706].alt_alleles == "C"
+    assert df.iloc[706].effect == "NON_SYNONYMOUS_CODING"
+    assert df.iloc[706].impact == "MODERATE"
+    assert df.iloc[706].ref_codon == "gaG"
+    assert df.iloc[706].alt_codon == "gaC"
+    assert df.iloc[706].aa_pos == 35
+    assert df.iloc[706].ref_aa == "E"
+    assert df.iloc[706].alt_aa == "D"
+    assert df.iloc[706].aa_change == "E35D"
+    # check syn
+    assert df.iloc[705].aa_change == 'E35E'
+    # check intronic
+    assert df.iloc[900].effect == 'INTRONIC'
+    # check 5' utr
+    assert df.iloc[0].effect == 'FIVE_PRIME_UTR'
+    # check 3' utr
+    assert df.iloc[2828].effect == 'THREE_PRIME_UTR'
+
+    # check 5' utr intron and the different intron effects
+    utrintron5 = "AGAP004679-RB"
+    df = ag3.snp_effects(utrintron5, site_mask)
+    assert isinstance(df, pandas.DataFrame)
+    assert expected_fields == df.columns.tolist()
+    assert df.shape == (7686, 11)
+    assert df.loc[180].effect == 'SPLICE_CORE'
+    assert df.loc[198].effect == 'SPLICE_REGION'
+    assert df.loc[202].effect == 'INTRONIC'
 
     # check 3' utr intron
-    # utrintron3 = "AGAP004679-RB"
-    # df = ag3.snp_effects(utrintron3, site_mask)
-    # assert isinstance(df, pandas.DataFrame)
-    # assert expected_fields == df.columns.tolist()
-    # assert df.shape == (7686, 11)
-    # assert df.loc[180].effect == 'INTRONIC
+    utrintron3 = "AGAP000689-RA"
+    df = ag3.snp_effects(utrintron3, site_mask)
+    assert isinstance(df, pandas.DataFrame)
+    assert expected_fields == df.columns.tolist()
+    assert df.shape == (5397, 11)
+    assert df.loc[646].effect == 'SPLICE_CORE'
+    assert df.loc[652].effect == 'SPLICE_REGION'
+    assert df.loc[674].effect == 'INTRONIC'

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -485,7 +485,7 @@ def test_snp_effects():
     site_mask = "gamb_colu"
     expected_fields = ["position",
                        "ref_allele",
-                       "alt_alleles",
+                       "alt_allele",
                        "effect",
                        "impact",
                        "ref_codon",
@@ -508,7 +508,7 @@ def test_snp_effects():
     # while we are here, check all columns for a position
     assert df.iloc[1451].position == 28598166
     assert df.iloc[1451].ref_allele == "A"
-    assert df.iloc[1451].alt_alleles == "G"
+    assert df.iloc[1451].alt_allele == "G"
     assert df.iloc[1451].effect == "NON_SYNONYMOUS_CODING"
     assert df.iloc[1451].impact == "MODERATE"
     assert df.iloc[1451].ref_codon == "aTt"
@@ -539,7 +539,7 @@ def test_snp_effects():
     # while we are here, check all columns for a position
     assert df.iloc[706].position == 28600605
     assert df.iloc[706].ref_allele == "G"
-    assert df.iloc[706].alt_alleles == "C"
+    assert df.iloc[706].alt_allele == "C"
     assert df.iloc[706].effect == "NON_SYNONYMOUS_CODING"
     assert df.iloc[706].impact == "MODERATE"
     assert df.iloc[706].ref_codon == "gaG"


### PR DESCRIPTION
- fixes bug in intron code (we weren't getting splice site effects due to `else` instead of `elif`.
- removes the single snp effect method/tests, on reflection this wasn't adding anything helpful.
- Adds intron tests.