### PR TITLE
Profile veff with snakeviz demo

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1187,6 +1187,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "snakeviz"
+version = "2.1.0"
+description = "A web-based viewer for Python profiler output"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+tornado = ">=2.0"
+
+[[package]]
 name = "sortedcontainers"
 version = "2.3.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
@@ -1399,7 +1410,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.9"
-content-hash = "2c22acddfb51c76a31b73be63ff957b1040e071563cd8d0a9f5c03762b755718"
+content-hash = "8e66949daa22626834d162554b17fa08c1def9d48681a2f57155a542c3a6ee02"
 
 [metadata.files]
 aiohttp = [
@@ -2208,6 +2219,10 @@ send2trash = [
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+]
+snakeviz = [
+    {file = "snakeviz-2.1.0-py2.py3-none-any.whl", hash = "sha256:8ce375b18ae4a749516d7e6c6fbbf8be6177c53974f53534d8eadb646cd279b1"},
+    {file = "snakeviz-2.1.0.tar.gz", hash = "sha256:92ad876fb6a201a7e23a6b85ea96d9643a51e285667c253a8653643804f7cb68"},
 ]
 sortedcontainers = [
     {file = "sortedcontainers-2.3.0-py2.py3-none-any.whl", hash = "sha256:37257a32add0a3ee490bb170b599e93095eed89a55da91fa9f48753ea12fd73f"},

--- a/prototyping/profile_snp_effects.ipynb
+++ b/prototyping/profile_snp_effects.ipynb
@@ -1,0 +1,526 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "91a13125",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import malariagen_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ca7068a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3 = malariagen_data.Ag3(\"simplecache::gs://vo_agam_release/\", \n",
+    "                          simplecache=dict(cache_storage=\"../gcs_cache\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f8bd8145",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gste2 = \"AGAP009194-RA\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e1f8d5de",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 23.6 s, sys: 203 ms, total: 23.8 s\n",
+      "Wall time: 23.7 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "ag3 = malariagen_data.Ag3(\"simplecache::gs://vo_agam_release/\", \n",
+    "                          simplecache=dict(cache_storage=\"../gcs_cache\"))\n",
+    "df = ag3.snp_effects(transcript=gste2, site_mask=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f54d6fd7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 661 ms, sys: 55.7 ms, total: 716 ms\n",
+      "Wall time: 683 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time \n",
+    "df = ag3.snp_effects(transcript=gste2, site_mask=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "9af48806",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>position</th>\n",
+       "      <th>ref_allele</th>\n",
+       "      <th>alt_allele</th>\n",
+       "      <th>effect</th>\n",
+       "      <th>impact</th>\n",
+       "      <th>ref_codon</th>\n",
+       "      <th>alt_codon</th>\n",
+       "      <th>aa_pos</th>\n",
+       "      <th>ref_aa</th>\n",
+       "      <th>alt_aa</th>\n",
+       "      <th>aa_change</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>28597652</td>\n",
+       "      <td>G</td>\n",
+       "      <td>A</td>\n",
+       "      <td>THREE_PRIME_UTR</td>\n",
+       "      <td>LOW</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>28597652</td>\n",
+       "      <td>G</td>\n",
+       "      <td>C</td>\n",
+       "      <td>THREE_PRIME_UTR</td>\n",
+       "      <td>LOW</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>28597652</td>\n",
+       "      <td>G</td>\n",
+       "      <td>T</td>\n",
+       "      <td>THREE_PRIME_UTR</td>\n",
+       "      <td>LOW</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>28597653</td>\n",
+       "      <td>A</td>\n",
+       "      <td>C</td>\n",
+       "      <td>THREE_PRIME_UTR</td>\n",
+       "      <td>LOW</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>28597653</td>\n",
+       "      <td>A</td>\n",
+       "      <td>T</td>\n",
+       "      <td>THREE_PRIME_UTR</td>\n",
+       "      <td>LOW</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2962</th>\n",
+       "      <td>28598639</td>\n",
+       "      <td>C</td>\n",
+       "      <td>T</td>\n",
+       "      <td>FIVE_PRIME_UTR</td>\n",
+       "      <td>LOW</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2963</th>\n",
+       "      <td>28598639</td>\n",
+       "      <td>C</td>\n",
+       "      <td>G</td>\n",
+       "      <td>FIVE_PRIME_UTR</td>\n",
+       "      <td>LOW</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2964</th>\n",
+       "      <td>28598640</td>\n",
+       "      <td>G</td>\n",
+       "      <td>A</td>\n",
+       "      <td>FIVE_PRIME_UTR</td>\n",
+       "      <td>LOW</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2965</th>\n",
+       "      <td>28598640</td>\n",
+       "      <td>G</td>\n",
+       "      <td>C</td>\n",
+       "      <td>FIVE_PRIME_UTR</td>\n",
+       "      <td>LOW</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2966</th>\n",
+       "      <td>28598640</td>\n",
+       "      <td>G</td>\n",
+       "      <td>T</td>\n",
+       "      <td>FIVE_PRIME_UTR</td>\n",
+       "      <td>LOW</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>2967 rows × 11 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      position ref_allele alt_allele           effect impact ref_codon  \\\n",
+       "0     28597652          G          A  THREE_PRIME_UTR    LOW      None   \n",
+       "1     28597652          G          C  THREE_PRIME_UTR    LOW      None   \n",
+       "2     28597652          G          T  THREE_PRIME_UTR    LOW      None   \n",
+       "3     28597653          A          C  THREE_PRIME_UTR    LOW      None   \n",
+       "4     28597653          A          T  THREE_PRIME_UTR    LOW      None   \n",
+       "...        ...        ...        ...              ...    ...       ...   \n",
+       "2962  28598639          C          T   FIVE_PRIME_UTR    LOW      None   \n",
+       "2963  28598639          C          G   FIVE_PRIME_UTR    LOW      None   \n",
+       "2964  28598640          G          A   FIVE_PRIME_UTR    LOW      None   \n",
+       "2965  28598640          G          C   FIVE_PRIME_UTR    LOW      None   \n",
+       "2966  28598640          G          T   FIVE_PRIME_UTR    LOW      None   \n",
+       "\n",
+       "     alt_codon  aa_pos ref_aa alt_aa aa_change  \n",
+       "0         None     NaN   None   None      None  \n",
+       "1         None     NaN   None   None      None  \n",
+       "2         None     NaN   None   None      None  \n",
+       "3         None     NaN   None   None      None  \n",
+       "4         None     NaN   None   None      None  \n",
+       "...        ...     ...    ...    ...       ...  \n",
+       "2962      None     NaN   None   None      None  \n",
+       "2963      None     NaN   None   None      None  \n",
+       "2964      None     NaN   None   None      None  \n",
+       "2965      None     NaN   None   None      None  \n",
+       "2966      None     NaN   None   None      None  \n",
+       "\n",
+       "[2967 rows x 11 columns]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "03373ed3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vgsc = \"AGAP004707-RA\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "3300090f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "transcript : AGAP004707-RA\n",
+      "chromosome : 2L \n",
+      "start : 2358158\n",
+      "stop : 2431617\n",
+      "strand : +\n",
+      "CPU times: user 1min 54s, sys: 167 ms, total: 1min 54s\n",
+      "Wall time: 1min 54s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "ag3 = malariagen_data.Ag3(\"simplecache::gs://vo_agam_release/\", \n",
+    "                          simplecache=dict(cache_storage=\"../gcs_cache\"))\n",
+    "df = ag3.snp_effects(transcript=vgsc, site_mask=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "14a05666",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "transcript : AGAP004707-RA\n",
+      "chromosome : 2L \n",
+      "start : 2358158\n",
+      "stop : 2431617\n",
+      "strand : +\n",
+      "CPU times: user 1min 37s, sys: 91.1 ms, total: 1min 37s\n",
+      "Wall time: 1min 37s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "df = ag3.snp_effects(transcript=vgsc, site_mask=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "08384655",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext snakeviz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a92515cb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " \n",
+      "*** Profile stats marshalled to file '/tmp/tmpfh8iywml'. \n",
+      "Embedding SnakeViz in this document...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<iframe id='snakeviz-40cb7572-a28b-11eb-8f4f-0c7a154f95d4' frameborder=0 seamless width='100%' height='1000'></iframe>\n",
+       "<script>document.getElementById(\"snakeviz-40cb7572-a28b-11eb-8f4f-0c7a154f95d4\").setAttribute(\"src\", \"http://\" + document.location.hostname + \":8080/snakeviz/%2Ftmp%2Ftmpfh8iywml\")</script>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ag3 = malariagen_data.Ag3(\"simplecache::gs://vo_agam_release/\", \n",
+    "                          simplecache=dict(cache_storage=\"../gcs_cache\"))\n",
+    "%snakeviz ag3.snp_effects(transcript=gste2, site_mask=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3b774f13",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " \n",
+      "*** Profile stats marshalled to file '/tmp/tmp_a_scjzg'. \n",
+      "Embedding SnakeViz in this document...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<iframe id='snakeviz-434f9c92-a28b-11eb-8f4f-0c7a154f95d4' frameborder=0 seamless width='100%' height='1000'></iframe>\n",
+       "<script>document.getElementById(\"snakeviz-434f9c92-a28b-11eb-8f4f-0c7a154f95d4\").setAttribute(\"src\", \"http://\" + document.location.hostname + \":8080/snakeviz/%2Ftmp%2Ftmp_a_scjzg\")</script>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%snakeviz ag3.snp_effects(transcript=gste2, site_mask=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "af81ad9c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "transcript : AGAP004707-RA\n",
+      "chromosome : 2L \n",
+      "start : 2358158\n",
+      "stop : 2431617\n",
+      "strand : +\n",
+      " \n",
+      "*** Profile stats marshalled to file '/tmp/tmp6vsdcyxb'. \n",
+      "Embedding SnakeViz in this document...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<iframe id='snakeviz-a78e4874-9b70-11eb-a11e-0c7a154f95d4' frameborder=0 seamless width='100%' height='1000'></iframe>\n",
+       "<script>document.getElementById(\"snakeviz-a78e4874-9b70-11eb-a11e-0c7a154f95d4\").setAttribute(\"src\", \"http://\" + document.location.hostname + \":8080/snakeviz/%2Ftmp%2Ftmp6vsdcyxb\")</script>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%snakeviz ag3.snp_effects(transcript=vgsc, site_mask=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3058d188",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/prototyping/profile_snp_effects.ipynb
+++ b/prototyping/profile_snp_effects.ipynb
@@ -41,13 +41,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 23.6 s, sys: 203 ms, total: 23.8 s\n",
-      "Wall time: 23.7 s\n"
+      "CPU times: user 21.3 s, sys: 171 ms, total: 21.5 s\n",
+      "Wall time: 21.4 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
+    "# by instantiating ag3 again here, we can measure the time required\n",
+    "# to setup the variant annotator\n",
     "ag3 = malariagen_data.Ag3(\"simplecache::gs://vo_agam_release/\", \n",
     "                          simplecache=dict(cache_storage=\"../gcs_cache\"))\n",
     "df = ag3.snp_effects(transcript=gste2, site_mask=None)"
@@ -63,13 +65,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 661 ms, sys: 55.7 ms, total: 716 ms\n",
-      "Wall time: 683 ms\n"
+      "CPU times: user 560 ms, sys: 44.9 ms, total: 605 ms\n",
+      "Wall time: 598 ms\n"
      ]
     }
    ],
    "source": [
     "%%time \n",
+    "# now the variant annotator should have been cached, we can\n",
+    "# measure the time taken to compute snp effects\n",
     "df = ag3.snp_effects(transcript=gste2, site_mask=None)"
    ]
   },
@@ -314,7 +318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 7,
    "id": "03373ed3",
    "metadata": {},
    "outputs": [],
@@ -324,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 8,
    "id": "3300090f",
    "metadata": {},
    "outputs": [
@@ -332,13 +336,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "transcript : AGAP004707-RA\n",
-      "chromosome : 2L \n",
-      "start : 2358158\n",
-      "stop : 2431617\n",
-      "strand : +\n",
-      "CPU times: user 1min 54s, sys: 167 ms, total: 1min 54s\n",
-      "Wall time: 1min 54s\n"
+      "CPU times: user 1min 59s, sys: 100 ms, total: 2min\n",
+      "Wall time: 1min 59s\n"
      ]
     }
    ],
@@ -351,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 9,
    "id": "14a05666",
    "metadata": {},
    "outputs": [
@@ -359,13 +358,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "transcript : AGAP004707-RA\n",
-      "chromosome : 2L \n",
-      "start : 2358158\n",
-      "stop : 2431617\n",
-      "strand : +\n",
-      "CPU times: user 1min 37s, sys: 91.1 ms, total: 1min 37s\n",
-      "Wall time: 1min 37s\n"
+      "CPU times: user 1min 40s, sys: 24.3 ms, total: 1min 40s\n",
+      "Wall time: 1min 40s\n"
      ]
     }
    ],
@@ -376,7 +370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "id": "08384655",
    "metadata": {},
    "outputs": [],
@@ -386,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "a92515cb",
    "metadata": {},
    "outputs": [
@@ -395,7 +389,7 @@
      "output_type": "stream",
      "text": [
       " \n",
-      "*** Profile stats marshalled to file '/tmp/tmpfh8iywml'. \n",
+      "*** Profile stats marshalled to file '/tmp/tmprbvht8ft'. \n",
       "Embedding SnakeViz in this document...\n"
      ]
     },
@@ -403,8 +397,8 @@
      "data": {
       "text/html": [
        "\n",
-       "<iframe id='snakeviz-40cb7572-a28b-11eb-8f4f-0c7a154f95d4' frameborder=0 seamless width='100%' height='1000'></iframe>\n",
-       "<script>document.getElementById(\"snakeviz-40cb7572-a28b-11eb-8f4f-0c7a154f95d4\").setAttribute(\"src\", \"http://\" + document.location.hostname + \":8080/snakeviz/%2Ftmp%2Ftmpfh8iywml\")</script>\n"
+       "<iframe id='snakeviz-28dd72b6-a291-11eb-8f4f-0c7a154f95d4' frameborder=0 seamless width='100%' height='1000'></iframe>\n",
+       "<script>document.getElementById(\"snakeviz-28dd72b6-a291-11eb-8f4f-0c7a154f95d4\").setAttribute(\"src\", \"http://\" + document.location.hostname + \":8080/snakeviz/%2Ftmp%2Ftmprbvht8ft\")</script>\n"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -415,6 +409,8 @@
     }
    ],
    "source": [
+    "# by instantiating ag3 again here, we can profile the time required\n",
+    "# to setup the variant annotator\n",
     "ag3 = malariagen_data.Ag3(\"simplecache::gs://vo_agam_release/\", \n",
     "                          simplecache=dict(cache_storage=\"../gcs_cache\"))\n",
     "%snakeviz ag3.snp_effects(transcript=gste2, site_mask=None)"
@@ -422,7 +418,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "3b774f13",
    "metadata": {},
    "outputs": [
@@ -431,7 +427,7 @@
      "output_type": "stream",
      "text": [
       " \n",
-      "*** Profile stats marshalled to file '/tmp/tmp_a_scjzg'. \n",
+      "*** Profile stats marshalled to file '/tmp/tmp5zmt0py6'. \n",
       "Embedding SnakeViz in this document...\n"
      ]
     },
@@ -439,8 +435,8 @@
      "data": {
       "text/html": [
        "\n",
-       "<iframe id='snakeviz-434f9c92-a28b-11eb-8f4f-0c7a154f95d4' frameborder=0 seamless width='100%' height='1000'></iframe>\n",
-       "<script>document.getElementById(\"snakeviz-434f9c92-a28b-11eb-8f4f-0c7a154f95d4\").setAttribute(\"src\", \"http://\" + document.location.hostname + \":8080/snakeviz/%2Ftmp%2Ftmp_a_scjzg\")</script>\n"
+       "<iframe id='snakeviz-2b54364c-a291-11eb-8f4f-0c7a154f95d4' frameborder=0 seamless width='100%' height='1000'></iframe>\n",
+       "<script>document.getElementById(\"snakeviz-2b54364c-a291-11eb-8f4f-0c7a154f95d4\").setAttribute(\"src\", \"http://\" + document.location.hostname + \":8080/snakeviz/%2Ftmp%2Ftmp5zmt0py6\")</script>\n"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -451,12 +447,14 @@
     }
    ],
    "source": [
+    "# now the variant annotator should have been cached, we can\n",
+    "# profile the time taken to compute snp effects\n",
     "%snakeviz ag3.snp_effects(transcript=gste2, site_mask=None)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 13,
    "id": "af81ad9c",
    "metadata": {},
    "outputs": [
@@ -464,13 +462,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "transcript : AGAP004707-RA\n",
-      "chromosome : 2L \n",
-      "start : 2358158\n",
-      "stop : 2431617\n",
-      "strand : +\n",
       " \n",
-      "*** Profile stats marshalled to file '/tmp/tmp6vsdcyxb'. \n",
+      "*** Profile stats marshalled to file '/tmp/tmpqk6rlzu7'. \n",
       "Embedding SnakeViz in this document...\n"
      ]
     },
@@ -478,8 +471,8 @@
      "data": {
       "text/html": [
        "\n",
-       "<iframe id='snakeviz-a78e4874-9b70-11eb-a11e-0c7a154f95d4' frameborder=0 seamless width='100%' height='1000'></iframe>\n",
-       "<script>document.getElementById(\"snakeviz-a78e4874-9b70-11eb-a11e-0c7a154f95d4\").setAttribute(\"src\", \"http://\" + document.location.hostname + \":8080/snakeviz/%2Ftmp%2Ftmp6vsdcyxb\")</script>\n"
+       "<iframe id='snakeviz-7d1453c2-a291-11eb-8f4f-0c7a154f95d4' frameborder=0 seamless width='100%' height='1000'></iframe>\n",
+       "<script>document.getElementById(\"snakeviz-7d1453c2-a291-11eb-8f4f-0c7a154f95d4\").setAttribute(\"src\", \"http://\" + document.location.hostname + \":8080/snakeviz/%2Ftmp%2Ftmpqk6rlzu7\")</script>\n"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -490,6 +483,8 @@
     }
    ],
    "source": [
+    "# now the variant annotator should have been cached, we can\n",
+    "# profile the time taken to compute snp effects on a bigger gene\n",
     "%snakeviz ag3.snp_effects(transcript=vgsc, site_mask=None)"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ pytest = "*"
 notebook = "*"
 pre-commit = "*"
 black = "*"
+snakeviz = "*"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Hi @cclarkson, here's the notebook I used to profile snp_effects with snakeviz. Note that there is still some weirdness here with snakeviz where it sometimes doesn't show the full icicle chart, but if so you can fix that by scrolling to the table below, sorting by cumtime, then clicking on ag3.snp_effects() row, which will set that as the root of the icicle chart.