### PR TITLE
Ag3 CNV methods

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -1117,39 +1117,52 @@ class Ag3:
         root = self.open_cnv_hmm(sample_set=sample_set)
 
         # variant arrays
-        pos_z = root[contig]["variants"]["POS"]
-        pos = from_zarr(pos_z, inline_array=inline_array, chunks=chunks)
-        coords["variant_position"] = [DIM_VARIANT], pos
-        end_z = root[contig]["variants"]["END"]
-        end = from_zarr(end_z, inline_array=inline_array, chunks=chunks)
-        coords["variant_end"] = [DIM_VARIANT], end
+        pos = root[f"{contig}/variants/POS"]
+        coords["variant_position"] = (
+            [DIM_VARIANT],
+            from_zarr(pos, inline_array=inline_array, chunks=chunks),
+        )
+        coords["variant_end"] = (
+            [DIM_VARIANT],
+            from_zarr(
+                root[f"{contig}/variants/END"], inline_array=inline_array, chunks=chunks
+            ),
+        )
         contig_index = self.contigs.index(contig)
-        contig_arr = da.full_like(pos, fill_value=contig_index, dtype="u1")
-        coords["variant_contig"] = [DIM_VARIANT], contig_arr
+        coords["variant_contig"] = (
+            [DIM_VARIANT],
+            da.full_like(pos, fill_value=contig_index, dtype="u1"),
+        )
 
         # call arrays
-        cn_z = root[contig]["calldata"]["CN"]
-        cn = from_zarr(cn_z, inline_array=inline_array, chunks=chunks)
-        raw_cov_z = root[contig]["calldata"]["RawCov"]
-        raw_cov = from_zarr(raw_cov_z, inline_array=inline_array, chunks=chunks)
-        norm_cov_z = root[contig]["calldata"]["NormCov"]
-        norm_cov = from_zarr(norm_cov_z, inline_array=inline_array, chunks=chunks)
-        data_vars["call_CN"] = ([DIM_VARIANT, DIM_SAMPLE], cn)
-        data_vars["call_RawCov"] = ([DIM_VARIANT, DIM_SAMPLE], raw_cov)
-        data_vars["call_NormCov"] = ([DIM_VARIANT, DIM_SAMPLE], norm_cov)
+        data_vars["call_CN"] = (
+            [DIM_VARIANT, DIM_SAMPLE],
+            from_zarr(
+                root[f"{contig}/calldata/CN"], inline_array=inline_array, chunks=chunks
+            ),
+        )
+        data_vars["call_RawCov"] = (
+            [DIM_VARIANT, DIM_SAMPLE],
+            from_zarr(
+                root[f"{contig}/calldata/RawCov"],
+                inline_array=inline_array,
+                chunks=chunks,
+            ),
+        )
+        data_vars["call_NormCov"] = (
+            [DIM_VARIANT, DIM_SAMPLE],
+            from_zarr(
+                root[f"{contig}/calldata/NormCov"],
+                inline_array=inline_array,
+                chunks=chunks,
+            ),
+        )
 
         # sample arrays
-        sample_id = from_zarr(root["samples"], inline_array=inline_array, chunks=chunks)
-        coords["sample_id"] = [DIM_SAMPLE], sample_id
-        # TODO add later when data available
-        # scv = from_zarr(
-        #     root["sample_coverage_variance"], inline_array=inline_array, chunks=chunks
-        # )
-        # data_vars["sample_coverage_variance"] = [DIM_SAMPLE], scv
-        # ihv = from_zarr(
-        #     root["sample_is_high_variance"], inline_array=inline_array, chunks=chunks
-        # )
-        # data_vars["sample_is_high_variance"] = [DIM_SAMPLE], ihv
+        coords["sample_id"] = (
+            [DIM_SAMPLE],
+            from_zarr(root["samples"], inline_array=inline_array, chunks=chunks),
+        )
 
         # setup attributes
         attrs = {"contigs": self.contigs}

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -1139,9 +1139,17 @@ class Ag3:
         data_vars["call_NormCov"] = ([DIM_VARIANT, DIM_SAMPLE], norm_cov)
 
         # sample arrays
-        z = root["samples"]
-        sample_id = from_zarr(z, inline_array=inline_array, chunks=chunks)
+        sample_id = from_zarr(root["samples"], inline_array=inline_array, chunks=chunks)
         coords["sample_id"] = [DIM_SAMPLE], sample_id
+        # TODO add later when data available
+        # scv = from_zarr(
+        #     root["sample_coverage_variance"], inline_array=inline_array, chunks=chunks
+        # )
+        # data_vars["sample_coverage_variance"] = [DIM_SAMPLE], scv
+        # ihv = from_zarr(
+        #     root["sample_is_high_variance"], inline_array=inline_array, chunks=chunks
+        # )
+        # data_vars["sample_is_high_variance"] = [DIM_SAMPLE], ihv
 
         # setup attributes
         attrs = {"contigs": self.contigs}

--- a/malariagen_data/util.py
+++ b/malariagen_data/util.py
@@ -117,7 +117,8 @@ def from_zarr(z, inline_array, chunks="auto"):
     our own here to get a little more control.
 
     """
-    if chunks == "native":
+    if chunks == "native" or z.dtype == object:
+        # N.B., dask does not support "auto" chunks for arrays with object dtype
         chunks = z.chunks
     kwargs = dict(chunks=chunks, fancy=False, lock=False, inline_array=inline_array)
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "malariagen_data"
-version = "0.5.0-alpha.0"
+version = "0.5.0-alpha.1"
 description = "A package for accessing MalariaGEN public data."
 authors = ["Alistair Miles <alimanfoo@googlemail.com>"]
 license = "MIT"
@@ -15,7 +15,6 @@ gcsfs = "*"
 petl = "*"
 petlx = "*"
 BioPython = "*"
-pyfasta = "*"
 intervaltree = "*"
 scikit-allel = "*"
 xarray = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "malariagen_data"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 description = "A package for accessing MalariaGEN public data."
 authors = ["Alistair Miles <alimanfoo@googlemail.com>"]
 license = "MIT"

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1,6 +1,6 @@
 import dask.array as da
 import numpy as np
-import pandas
+import pandas as pd
 import pytest
 import xarray
 import zarr
@@ -41,7 +41,7 @@ def test_sample_sets(url):
 
     ag3 = setup_ag3(url)
     df_sample_sets_v3 = ag3.sample_sets(release="v3")
-    assert isinstance(df_sample_sets_v3, pandas.DataFrame)
+    assert isinstance(df_sample_sets_v3, pd.DataFrame)
     assert 28 == len(df_sample_sets_v3)
     assert ("sample_set", "sample_count", "release") == tuple(df_sample_sets_v3.columns)
 
@@ -307,7 +307,7 @@ def test_geneset():
 
     # default
     df = ag3.geneset()
-    assert isinstance(df, pandas.DataFrame)
+    assert isinstance(df, pd.DataFrame)
     gff3_cols = [
         "seqid",
         "source",
@@ -323,7 +323,7 @@ def test_geneset():
 
     # don't unpack attributes
     df = ag3.geneset(attributes=None)
-    assert isinstance(df, pandas.DataFrame)
+    assert isinstance(df, pd.DataFrame)
     expected_cols = gff3_cols + ["attributes"]
     assert expected_cols == df.columns.tolist()
 
@@ -344,7 +344,7 @@ def test_cross_metadata():
 
     ag3 = setup_ag3()
     df_crosses = ag3.cross_metadata()
-    assert isinstance(df_crosses, pandas.DataFrame)
+    assert isinstance(df_crosses, pd.DataFrame)
     expected_cols = ["cross", "sample_id", "father_id", "mother_id", "sex", "role"]
     assert expected_cols == df_crosses.columns.tolist()
 
@@ -497,7 +497,7 @@ def test_snp_effects():
     ]
 
     df = ag3.snp_effects(gste2, site_mask)
-    assert isinstance(df, pandas.DataFrame)
+    assert isinstance(df, pd.DataFrame)
     assert expected_fields == df.columns.tolist()
 
     # reverse strand gene
@@ -529,7 +529,7 @@ def test_snp_effects():
     # test forward strand gene gste6
     gste6 = "AGAP009196-RA"
     df = ag3.snp_effects(gste6, site_mask)
-    assert isinstance(df, pandas.DataFrame)
+    assert isinstance(df, pd.DataFrame)
     assert expected_fields == df.columns.tolist()
     assert df.shape == (2829, 11)
 
@@ -560,7 +560,7 @@ def test_snp_effects():
     # check 5' utr intron and the different intron effects
     utrintron5 = "AGAP004679-RB"
     df = ag3.snp_effects(utrintron5, site_mask)
-    assert isinstance(df, pandas.DataFrame)
+    assert isinstance(df, pd.DataFrame)
     assert expected_fields == df.columns.tolist()
     assert df.shape == (7686, 11)
     assert df.loc[180].effect == "SPLICE_CORE"
@@ -570,7 +570,7 @@ def test_snp_effects():
     # check 3' utr intron
     utrintron3 = "AGAP000689-RA"
     df = ag3.snp_effects(utrintron3, site_mask)
-    assert isinstance(df, pandas.DataFrame)
+    assert isinstance(df, pd.DataFrame)
     assert expected_fields == df.columns.tolist()
     assert df.shape == (5397, 11)
     assert df.loc[646].effect == "SPLICE_CORE"
@@ -601,7 +601,7 @@ def test_snp_allele_frequencies():
         drop_invariant=True,
     )
 
-    assert isinstance(df, pandas.DataFrame)
+    assert isinstance(df, pd.DataFrame)
     assert expected_fields == df.columns.tolist()
     assert df.shape == (133, 6)
     assert df.loc[4].position == 28597653
@@ -634,7 +634,7 @@ def test_snp_allele_frequencies():
         drop_invariant=False,
     )
 
-    assert isinstance(df, pandas.DataFrame)
+    assert isinstance(df, pd.DataFrame)
     assert expected_fields == df.columns.tolist()
     assert df.shape == (132306, 6)
     assert df.loc[0].position == 2358158
@@ -714,4 +714,79 @@ def test_cnv_hmm(sample_sets, contig):
     d1 = ds["variant_position"] > 10_000
     assert isinstance(d1, xarray.DataArray)
     d2 = ds["call_CN"].sum(axis=1)
+    assert isinstance(d2, xarray.DataArray)
+
+
+@pytest.mark.parametrize("sample_set", ["AG1000G-AO", "AG1000G-UG", "AG1000G-X"])
+@pytest.mark.parametrize("analysis", ["gamb_colu", "arab", "crosses"])
+@pytest.mark.parametrize("contig", ["3L", "X"])
+def test_cnv_coverage_calls(sample_set, analysis, contig):
+
+    ag3 = setup_ag3()
+
+    expected_analyses = {
+        "AG1000G-AO": {"gamb_colu"},
+        "AG1000G-UG": {"gamb_colu", "arab"},
+        "AG1000G-X": {"crosses"},
+    }
+    if analysis not in expected_analyses[sample_set]:
+        with pytest.raises(NotImplementedError):
+            ag3.cnv_coverage_calls(
+                contig=contig, analysis=analysis, sample_set=sample_set
+            )
+        return
+
+    ds = ag3.cnv_coverage_calls(contig=contig, analysis=analysis, sample_set=sample_set)
+    assert isinstance(ds, xarray.Dataset)
+
+    # check fields
+    expected_data_vars = {
+        "variant_CIPOS",
+        "variant_CIEND",
+        "variant_filter_pass",
+        "call_genotype",
+    }
+    assert expected_data_vars == set(ds.data_vars)
+
+    expected_coords = {
+        "variant_contig",
+        "variant_position",
+        "variant_end",
+        "variant_id",
+        "sample_id",
+    }
+    assert expected_coords == set(ds.coords)
+
+    # check dimensions
+    assert {"samples", "variants"} == set(ds.dims)
+
+    # check sample IDs
+    df_samples = ag3.sample_metadata(sample_sets=sample_set, species_calls=None)
+    sample_id = pd.Series(ds["sample_id"].values)
+    assert sample_id.isin(df_samples["sample_id"]).all()
+
+    # check shapes
+    for f in expected_coords | expected_data_vars:
+        x = ds[f]
+        assert isinstance(x, xarray.DataArray)
+        assert isinstance(x.data, da.Array)
+
+        if f.startswith("variant_"):
+            assert 1 == x.ndim, f
+            assert ("variants",) == x.dims
+        elif f.startswith("call_"):
+            assert 2 == x.ndim, f
+            assert ("variants", "samples") == x.dims
+        elif f.startswith("sample_"):
+            assert 1 == x.ndim, f
+            assert ("samples",) == x.dims
+
+    # check attributes
+    assert "contigs" in ds.attrs
+    assert ("2R", "2L", "3R", "3L", "X") == ds.attrs["contigs"]
+
+    # check can setup computations
+    d1 = ds["variant_position"] > 10_000
+    assert isinstance(d1, xarray.DataArray)
+    d2 = ds["call_genotype"].sum(axis=1)
     assert isinstance(d2, xarray.DataArray)

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -663,9 +663,6 @@ def test_cnv_hmm(sample_sets, contig):
         "call_CN",
         "call_NormCov",
         "call_RawCov",
-        # TODO add later when data available
-        # "sample_coverage_variance",
-        # "sample_is_high_variance",
     }
     assert expected_data_vars == set(ds.data_vars)
 

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -663,6 +663,9 @@ def test_cnv_hmm(sample_sets, contig):
         "call_CN",
         "call_NormCov",
         "call_RawCov",
+        # TODO add later when data available
+        # "sample_coverage_variance",
+        # "sample_is_high_variance",
     }
     assert expected_data_vars == set(ds.data_vars)
 


### PR DESCRIPTION
This PR adds public methods to the Ag3 class for accessing copy number variation (CNV) data from Ag1000G phase 3, in particular:

* Ag3.cnv_hmm()
* Ag3.cnv_coverage_calls()
* Ag3.cnv_discordant_read_calls()

All methods return xarray datasets.