### PR TITLE
Maintenance on SNP effects and allele frequencies functions

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -406,7 +406,8 @@ class Ag3:
         contig : str
             Chromosome arm, e.g., "3R".
         field : {"POS", "REF", "ALT"}, optional
-            Array to access. If not provided, all three arrays POS, REF, ALT will be returned as a tuple.
+            Array to access. If not provided, all three arrays POS, REF, ALT will be returned as a
+            tuple.
         site_mask : {"gamb_colu_arab", "gamb_colu", "arab"}
             Site filters mask to apply.
         site_filters : str
@@ -723,7 +724,8 @@ class Ag3:
             identifiers (e.g., ["AG1000G-BF-A", "AG1000G-BF-B"]) or a release identifier (e.g.,
             "v3") or a list of release identifiers.
         drop_invariant : bool, optional
-            If True, variants with no alternate allele calls in any populations are dropped from the result.
+            If True, variants with no alternate allele calls in any populations are dropped from
+            the result.
 
         Returns
         -------

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -568,7 +568,7 @@ class Ag3:
         d = from_zarr(z, inline_array=inline_array, chunks=chunks)
         return d
 
-    def geneset(self, attributes=("ID", "Parent", "Name")):
+    def geneset(self, attributes=("ID", "Parent", "Name", "description")):
         """Access genome feature annotations (AgamP4.12).
 
         Parameters

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -810,13 +810,13 @@ class Ag3:
         # build df
         df = pandas.DataFrame(cols)
 
+        # add max allele freq column
+        df["max_af"] = df[populations].max(axis=1)
+
         # drop invariants
         if drop_invariant:
-            loc_variant = df[populations].sum(axis=1) > 0
+            loc_variant = df["max_af"] > 0
             df = df[loc_variant]
-
-        # add max freq column
-        df["maximum"] = df[populations].max(axis=1)
 
         return df
 

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -744,12 +744,7 @@ class Ag3:
 
         """
         # get feature details (don't need to set up an annotator here)
-        gs = self.geneset()
-        gs.rename(
-            columns={"ID": "feature_id", "Parent": "parent_id", "end": "stop"},
-            inplace=True,
-        )
-        geneset = gs.set_index("feature_id")
+        geneset = self.geneset().set_index("ID")
         feature = geneset.loc[transcript]
         contig = feature.contig
 
@@ -758,7 +753,7 @@ class Ag3:
 
         # locate transcript range
         pos = allel.SortedIndex(pos.compute())
-        loc_feature = pos.locate_range(feature.start, feature.stop)
+        loc_feature = pos.locate_range(feature.start, feature.end)
 
         # we want to grab all metadata then get idx for samples we want
         df_meta = self.sample_metadata(

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -659,7 +659,7 @@ class Ag3:
 
         # grab pos, ref and alt for chrom arm from snp_sites
         pos, ref, alt = self.snp_sites(
-            contig=feature.seqid, site_mask=site_mask, site_filters=site_filters
+            contig=feature.contig, site_mask=site_mask, site_filters=site_filters
         )
 
         # sites are dask arrays, turn pos into sorted index
@@ -740,7 +740,7 @@ class Ag3:
         )
         geneset = gs.set_index("feature_id")
         feature = geneset.loc[transcript]
-        contig = feature.seqid
+        contig = feature.contig
         start = feature.start
         stop = feature.stop
 

--- a/malariagen_data/util.py
+++ b/malariagen_data/util.py
@@ -27,7 +27,7 @@ def gff3_parse_attributes(attributes_string):
 
 
 gff3_cols = (
-    "seqid",
+    "contig",
     "source",
     "type",
     "start",

--- a/malariagen_data/veff.py
+++ b/malariagen_data/veff.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function
-
 import collections
 import operator
 
@@ -201,7 +199,9 @@ def _get_within_transcript_effect(ann, base_effect, cdss, utr5, utr3, introns):
         if start <= ref_start and stop >= ref_stop
     ]
     if within_introns:
-        return _get_intron_effect(base_effect=base_effect, intron=within_introns[0])
+        return _get_within_intron_effect(
+            base_effect=base_effect, intron=within_introns[0]
+        )
 
     within_utr5 = [x for x in utr5 if x.start <= ref_start and x.end >= ref_stop]
     if within_utr5:
@@ -214,7 +214,7 @@ def _get_within_transcript_effect(ann, base_effect, cdss, utr5, utr3, introns):
         return effect
 
     # if none of the above
-    effect = base_effect.replace(effect="TODO", impact="UNKNOWN")
+    effect = base_effect._replace(effect="TODO", impact="UNKNOWN")
     return effect
 
 
@@ -450,42 +450,6 @@ def _get_coding_position(ref_start, ref_stop, cds, cdss):
         ref_cds_stop = offset + (cds.end - ref_start)
 
     return ref_cds_start, ref_cds_stop
-
-
-def _get_intron_effect(base_effect, intron):
-
-    # convenience
-    ref_start = base_effect.ref_start
-    ref_stop = base_effect.ref_stop
-    intron_start, intron_stop = intron
-
-    if ref_start < intron_start <= ref_stop <= intron_stop:
-
-        # TODO
-        # reference allele overhangs the start of the current intron
-        effect = base_effect._replace(effect="TODO")
-        return effect
-
-    elif intron_start <= ref_start <= intron_stop < ref_stop:
-
-        # TODO
-        # reference allele overhangs the end of the current intron
-        effect = base_effect._replace(effect="TODO")
-        return effect
-
-    elif ref_start < intron_start <= intron_stop < ref_stop:
-
-        # TODO
-        # reference allele entirely overlaps the current intron and
-        # overhangs at both ends
-        effect = base_effect._replace(effect="TODO")
-        return effect
-
-    else:
-
-        # reference allele falls within current intron
-        assert intron_start <= ref_start <= ref_stop <= intron_stop
-        return _get_within_intron_effect(base_effect, intron)
 
 
 def _get_within_intron_effect(base_effect, intron):

--- a/malariagen_data/veff.py
+++ b/malariagen_data/veff.py
@@ -114,14 +114,14 @@ class Annotator(object):
         laa_change = []
 
         # Now iterate over the transcript alt alleles
-        feature_seqid = feature.seqid
+        feature_contig = feature.contig
         feature_start = feature.start
         feature_stop = feature.end
         feature_strand = feature.strand
         for row in variants.itertuples(index=True):
 
             # some parameters
-            chrom = feature_seqid
+            chrom = feature_contig
             pos = row.position
             ref = row.ref_allele
             alt = row.alt_allele

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -309,7 +309,7 @@ def test_geneset():
     df = ag3.geneset()
     assert isinstance(df, pd.DataFrame)
     gff3_cols = [
-        "seqid",
+        "contig",
         "source",
         "type",
         "start",

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -318,7 +318,7 @@ def test_geneset():
         "strand",
         "phase",
     ]
-    expected_cols = gff3_cols + ["ID", "Parent", "Name"]
+    expected_cols = gff3_cols + ["ID", "Parent", "Name", "description"]
     assert expected_cols == df.columns.tolist()
 
     # don't unpack attributes
@@ -590,7 +590,7 @@ def test_snp_allele_frequencies():
         "alt_allele",
         "ke",
         "bf_2012_col",
-        "maximum",
+        "max_af",
     ]
     # drop invariants
     df = ag3.snp_allele_frequencies(
@@ -609,9 +609,9 @@ def test_snp_allele_frequencies():
     assert df.loc[13].alt_allele == "C"
     assert df.loc[16].ke == 0
     assert df.loc[22].bf_2012_col == pytest.approx(0.006097, abs=1e-6)
-    assert df.loc[39].maximum == pytest.approx(0.006097, abs=1e-6)
+    assert df.loc[39].max_af == pytest.approx(0.006097, abs=1e-6)
     # check invariant have been dropped
-    assert df.maximum.min() > 0
+    assert df.max_af.min() > 0
 
     populations = {
         "gm": "country == 'Gambia, The'",

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -623,7 +623,7 @@ def test_snp_allele_frequencies():
         "alt_allele",
         "gm",
         "mz",
-        "maximum",
+        "max_af",
     ]
     # keep invariants
     df = ag3.snp_allele_frequencies(
@@ -642,9 +642,9 @@ def test_snp_allele_frequencies():
     assert df.loc[2].alt_allele == "G"
     assert df.loc[3].gm == 0.0
     assert df.loc[4].mz == 0.0
-    assert df.loc[72].maximum == pytest.approx(0.001792, abs=1e-6)
+    assert df.loc[72].max_af == pytest.approx(0.001792, abs=1e-6)
     # check invariant positions are still present
-    assert np.any(df.maximum == 0)
+    assert np.any(df.max_af == 0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR has several pieces of maintenance, which came up as worth doing while working on the SNP effects example notebook. Includes:

* clean up intron effects and make get_effects() a method (resolves #36)
* rename seqid to contig (resolves #37)
* accelerate snp_effects and snp_allele_frequencies with site mask
* fix unnecessary geneset renaming (resolves #41)
* add description to default cols (resolves #42)
* rename maximum to max_af (resolves #43)
