### PR TITLE
Raise error if zero samples selected for allele frequency calculations

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -796,6 +796,9 @@ class Ag3:
         for coh, query in cohorts.items():
             # locate samples
             loc_coh = df_meta.eval(query).values
+            n_samples = np.count_nonzero(loc_coh)
+            if n_samples == 0:
+                raise ValueError(f"no samples for cohort {coh!r}")
             gt_coh = np.compress(loc_coh, gt, axis=1)
             # count alleles
             ac_coh = allel.GenotypeArray(gt_coh).count_alleles(max_allele=3)

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1059,17 +1059,7 @@ def test_gene_cnv_frequencies_0_cohort(contig):
     cohorts = {
         "bf_2050_col": "country == 'Burkina Faso' and year == 2050 and species == 'coluzzii'",
     }
-    # with self.assertRaises(ValueError):
-    #     df = ag3.gene_cnv_frequencies(contig=contig, sample_sets="v3_wild", cohorts=cohorts)
-    #
-    try:
+    with pytest.raises(ValueError):
         _ = ag3.gene_cnv_frequencies(
             contig=contig, sample_sets="v3_wild", cohorts=cohorts
         )
-    except ValueError:
-        # The exception was raised as expected
-        pass
-    else:
-        # If we get here, then the ValueError was not raised
-        # raise an exception so that the test fails
-        raise AssertionError("ValueError was not raised")

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -664,6 +664,29 @@ def test_snp_allele_frequencies():
     assert np.any(df.max_af == 0)
 
 
+def test_snp_allele_frequencies_0_cohort():
+    ag3 = setup_ag3()
+    cohorts = {
+        "bf_2050_col": "country == 'Burkina Faso' and year == 2050 and species == 'coluzzii'",
+    }
+
+    try:
+        _ = ag3.snp_allele_frequencies(
+            transcript="AGAP009194-RA",
+            cohorts=cohorts,
+            site_mask="gamb_colu",
+            sample_sets="v3_wild",
+            drop_invariant=True,
+        )
+    except ValueError:
+        # The exception was raised as expected
+        pass
+    else:
+        # If we get here, then the ValueError was not raised
+        # raise an exception so that the test fails
+        raise AssertionError("ValueError was not raised")
+
+
 @pytest.mark.parametrize(
     "sample_sets", ["AG1000G-AO", ("AG1000G-AO", "AG1000G-UG"), "v3_wild"]
 )
@@ -1030,3 +1053,30 @@ def test_gene_cnv_frequencies(contig):
         x = a + d
         assert np.all(x >= 0)
         assert np.all(x <= 1)
+
+
+@pytest.mark.parametrize(
+    "contig",
+    [
+        "X",
+    ],
+)
+def test_gene_cnv_frequencies_0_cohort(contig):
+    ag3 = setup_ag3()
+    cohorts = {
+        "bf_2050_col": "country == 'Burkina Faso' and year == 2050 and species == 'coluzzii'",
+    }
+    # with self.assertRaises(ValueError):
+    #     df = ag3.gene_cnv_frequencies(contig=contig, sample_sets="v3_wild", cohorts=cohorts)
+    #
+    try:
+        _ = ag3.gene_cnv_frequencies(
+            contig=contig, sample_sets="v3_wild", cohorts=cohorts
+        )
+    except ValueError:
+        # The exception was raised as expected
+        pass
+    else:
+        # If we get here, then the ValueError was not raised
+        # raise an exception so that the test fails
+        raise AssertionError("ValueError was not raised")

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -670,7 +670,7 @@ def test_snp_allele_frequencies_0_cohort():
         "bf_2050_col": "country == 'Burkina Faso' and year == 2050 and species == 'coluzzii'",
     }
 
-    try:
+    with pytest.raises(ValueError):
         _ = ag3.snp_allele_frequencies(
             transcript="AGAP009194-RA",
             cohorts=cohorts,
@@ -678,13 +678,6 @@ def test_snp_allele_frequencies_0_cohort():
             sample_sets="v3_wild",
             drop_invariant=True,
         )
-    except ValueError:
-        # The exception was raised as expected
-        pass
-    else:
-        # If we get here, then the ValueError was not raised
-        # raise an exception so that the test fails
-        raise AssertionError("ValueError was not raised")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
resolves #50

Adds code to `SNP_allele_frequencies` which raises an error if zero samples in cohort (this code was already present for the CNV method which uses cohorts).

Adds tests for both methods.