### PR TITLE
Cohort access

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -98,6 +98,7 @@ class Ag3:
         self._cache_cnv_discordant_read_calls = dict()
         self._cache_haplotypes = dict()
         self._cache_haplotype_sites = dict()
+        self._cache_cohort_metadata = dict()
 
     @property
     def releases(self):
@@ -1909,3 +1910,52 @@ def _cn_mode(a, vmax):
         counts[j] = count
 
     return modes, counts
+
+
+def _read_cohort_metadata(self, *, sample_set):
+    """Read cohort metadata for a single sample set."""
+    try:
+        return self._cache_cohort_metadata[sample_set]
+    except KeyError:
+        release = self._lookup_release(sample_set=sample_set)
+        # TODO fix the path
+        path = f"{self._path}/{release}/metadata/general/{sample_set}/samples.meta.csv"
+        with self._fs.open(path) as f:
+            df = pandas.read_csv(f, na_values="")
+
+        # add a couple of columns for convenience
+        df["sample_set"] = sample_set
+        df["release"] = release
+
+        self._cache_cohort_metadata[sample_set] = df
+        return df
+
+
+def sample_cohorts(self, sample_sets="v3_wild", cohorts_analysis="20210702"):
+    """Access cohorts metadata for one or more sample sets.
+
+    Parameters
+    ----------
+    sample_sets : str or list of str
+        Can be a sample set identifier (e.g., "AG1000G-AO") or a list of sample set
+        identifiers (e.g., ["AG1000G-BF-A", "AG1000G-BF-B"]) or a release identifier (e.g.,
+        "v3") or a list of release identifiers.
+
+    Returns
+    -------
+    df : pandas.DataFrame
+
+    """
+
+    sample_sets = self._prep_sample_sets_arg(sample_sets=sample_sets)
+
+    if isinstance(sample_sets, str):
+        # assume single sample set
+        df = self._read_cohort_metadata(sample_set=sample_sets)
+
+    else:
+        # concatenate multiple sample sets
+        dfs = [self.cohort_metadata(sample_sets=c) for c in sample_sets]
+        df = pandas.concat(dfs, axis=0, sort=False).reset_index(drop=True)
+
+    return df

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -1893,9 +1893,6 @@ class Ag3:
         df : pandas.DataFrame
 
         """
-        # if v3, we don't want the colony crosses included
-        if sample_sets == "v3":
-            sample_sets = "v3_wild"
         sample_sets = self._prep_sample_sets_arg(sample_sets=sample_sets)
 
         if isinstance(sample_sets, str):

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -1864,20 +1864,20 @@ class Ag3:
 
         return ds
 
-    def _read_cohort_metadata(self, *, sample_set, cohort_analysis):
+    def _read_cohort_metadata(self, *, sample_set, cohorts_analysis):
         """Read cohort metadata for a single sample set."""
         try:
-            return self._cache_cohort_metadata[(sample_set, cohort_analysis)]
+            return self._cache_cohort_metadata[(sample_set, cohorts_analysis)]
         except KeyError:
             release = self._lookup_release(sample_set=sample_set)
-            path = f"{self._path}/{release}/metadata/cohorts_{cohort_analysis}/{sample_set}/samples.cohorts.csv"
+            path = f"{self._path}/{release}/metadata/cohorts_{cohorts_analysis}/{sample_set}/samples.cohorts.csv"
             with self._fs.open(path) as f:
                 df = pandas.read_csv(f, na_values="")
 
-            self._cache_cohort_metadata[(sample_set, cohort_analysis)] = df
+            self._cache_cohort_metadata[(sample_set, cohorts_analysis)] = df
             return df
 
-    def sample_cohorts(self, sample_sets="v3_wild", cohort_analysis="20210702"):
+    def sample_cohorts(self, sample_sets="v3_wild", cohorts_analysis="20210702"):
         """Access cohorts metadata for one or more sample sets.
 
         Parameters
@@ -1886,7 +1886,7 @@ class Ag3:
             Can be a sample set identifier (e.g., "AG1000G-AO") or a list of sample set
             identifiers (e.g., ["AG1000G-BF-A", "AG1000G-BF-B"]) or a release identifier (e.g.,
             "v3") or a list of release identifiers.
-        cohort_analysis : str
+        cohorts_analysis : str
             Cohort analysis identifier (date of analysis), default is latest version.
         Returns
         -------
@@ -1901,14 +1901,14 @@ class Ag3:
         if isinstance(sample_sets, str):
             # assume single sample set
             df = self._read_cohort_metadata(
-                sample_set=sample_sets, cohort_analysis=cohort_analysis
+                sample_set=sample_sets, cohorts_analysis=cohorts_analysis
             )
 
         else:
             # concatenate multiple sample sets
             dfs = [
                 self._read_cohort_metadata(
-                    sample_set=c, cohort_analysis=cohort_analysis
+                    sample_set=c, cohorts_analysis=cohorts_analysis
                 )
                 for c in sample_sets
             ]

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -1891,14 +1891,15 @@ class Ag3:
             identifiers (e.g., ["AG1000G-BF-A", "AG1000G-BF-B"]) or a release identifier (e.g.,
             "v3") or a list of release identifiers.
         cohort_analysis : str
-            Cohort analysis identifier (date of analysis), defaults is latest version.
+            Cohort analysis identifier (date of analysis), default is latest version.
         Returns
         -------
         df : pandas.DataFrame
 
         """
-        # TODO - check that cohort_analysis exists and return informative error if not.
-
+        # if v3, we don't want the colony crosses included
+        if sample_sets == "v3":
+            sample_sets = "v3_wild"
         sample_sets = self._prep_sample_sets_arg(sample_sets=sample_sets)
 
         if isinstance(sample_sets, str):

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -1874,10 +1874,6 @@ class Ag3:
             with self._fs.open(path) as f:
                 df = pandas.read_csv(f, na_values="")
 
-            # add a couple of columns for convenience
-            df["sample_set"] = sample_set
-            df["release"] = release
-
             self._cache_cohort_metadata[sample_set] = df
             return df
 

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -1867,14 +1867,14 @@ class Ag3:
     def _read_cohort_metadata(self, *, sample_set, cohort_analysis):
         """Read cohort metadata for a single sample set."""
         try:
-            return self._cache_cohort_metadata[sample_set]
+            return self._cache_cohort_metadata[(sample_set, cohort_analysis)]
         except KeyError:
             release = self._lookup_release(sample_set=sample_set)
             path = f"{self._path}/{release}/metadata/cohorts_{cohort_analysis}/{sample_set}/samples.cohorts.csv"
             with self._fs.open(path) as f:
                 df = pandas.read_csv(f, na_values="")
 
-            self._cache_cohort_metadata[sample_set] = df
+            self._cache_cohort_metadata[(sample_set, cohort_analysis)] = df
             return df
 
     def sample_cohorts(self, sample_sets="v3_wild", cohort_analysis="20210702"):

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1180,3 +1180,13 @@ def test_sample_cohorts():
     pd.testing.assert_frame_equal(df_v3, df_v3_wild)
 
     # test a single sample set
+    sample_sets = "AG1000G-UG"
+    df_UG = ag3.sample_cohorts(sample_sets=sample_sets)
+    assert df_UG.sample_id[0] == "AC0007-C"
+    assert df_UG.cohort_admin1_year[23] == "UG-E_2012_arab"
+    assert df_UG.cohort_admin1_month[37] == "UG-E_2012_10_arab"
+    assert df_UG.cohort_admin2_year[42] == "UG-E_Tororo_2012_arab"
+    assert df_UG.cohort_admin2_month[49] == "UG-E_Tororo_2012_10_arab"
+    assert df_UG.sample_set[67] == sample_sets
+    assert df_UG.release[93] == "v3"
+    assert df_UG.shape == (290, 7)

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1154,24 +1154,20 @@ def test_haplotypes(sample_sets, contig, analysis):
 
 # test v3 sample sets
 def test_sample_cohorts():
-    # TODO change staging to release once files copied over
     expected_cols = (
         "sample_id",
         "cohort_admin1_year",
         "cohort_admin1_month",
         "cohort_admin2_year",
         "cohort_admin2_month",
-        "sample_set",
-        "release",
     )
 
-    ag3 = Ag3("gs://vo_agam_staging/")
+    ag3 = setup_ag3()
 
     # test v3 wild
     sample_sets = "v3_wild"
     df_v3_wild = ag3.sample_cohorts(sample_sets=sample_sets)
     assert tuple(df_v3_wild.columns) == expected_cols
-    assert df_v3_wild.sample_set.unique()[-1] == "AG1000G-UG"
     assert len(df_v3_wild) == 2784
 
     # check v3 is the same
@@ -1187,6 +1183,4 @@ def test_sample_cohorts():
     assert df_UG.cohort_admin1_month[37] == "UG-E_2012_10_arab"
     assert df_UG.cohort_admin2_year[42] == "UG-E_Tororo_2012_arab"
     assert df_UG.cohort_admin2_month[49] == "UG-E_Tororo_2012_10_arab"
-    assert df_UG.sample_set[67] == sample_sets
-    assert df_UG.release[93] == "v3"
-    assert df_UG.shape == (290, 7)
+    assert df_UG.shape == (290, 5)

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1153,6 +1153,9 @@ def test_haplotypes(sample_sets, contig, analysis):
 
 
 # test v3 sample sets
+@pytest.mark.parametrize(
+    "sample_sets", ["v3_wild", "v3", "AG1000G-UG", ["AG1000G-AO", "AG1000G-FR"]]
+)
 def test_sample_cohorts():
     expected_cols = (
         "sample_id",

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1166,21 +1166,18 @@ def test_sample_cohorts(sample_sets):
     )
 
     ag3 = setup_ag3()
-    df_coh = ag3.sample_cohorts(sample_sets=sample_sets)
+    df_coh = ag3.sample_cohorts(sample_sets=sample_sets, cohorts_analysis="20210702")
+    df_meta = ag3.sample_metadata(sample_sets=sample_sets)
 
     assert tuple(df_coh.columns) == expected_cols
-    if sample_sets == "v3":
-        assert len(df_coh) == 3081
-    if sample_sets == "v3_wild":
-        assert len(df_coh) == 2784
+    assert len(df_coh) == len(df_meta)
+    assert df_coh.sample_id.tolist() == df_meta.sample_id.tolist()
     if sample_sets == "AG1000G-UG":
         assert df_coh.sample_id[0] == "AC0007-C"
         assert df_coh.cohort_admin1_year[23] == "UG-E_2012_arab"
         assert df_coh.cohort_admin1_month[37] == "UG-E_2012_10_arab"
         assert df_coh.cohort_admin2_year[42] == "UG-E_Tororo_2012_arab"
         assert df_coh.cohort_admin2_month[49] == "UG-E_Tororo_2012_10_arab"
-        assert df_coh.shape == (290, 5)
     if sample_sets == ["AG1000G-AO", "AG1000G-FR"]:
-        assert df_coh.shape == (104, 5)
         assert df_coh.sample_id[0] == "AR0047-C"
         assert df_coh.sample_id[103] == "AP0017-Cx"

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1156,7 +1156,7 @@ def test_haplotypes(sample_sets, contig, analysis):
 @pytest.mark.parametrize(
     "sample_sets", ["v3_wild", "v3", "AG1000G-UG", ["AG1000G-AO", "AG1000G-FR"]]
 )
-def test_sample_cohorts():
+def test_sample_cohorts(sample_sets):
     expected_cols = (
         "sample_id",
         "cohort_admin1_year",
@@ -1166,32 +1166,21 @@ def test_sample_cohorts():
     )
 
     ag3 = setup_ag3()
+    df_coh = ag3.sample_cohorts(sample_sets=sample_sets)
 
-    # test v3 wild
-    sample_sets = "v3_wild"
-    df_v3_wild = ag3.sample_cohorts(sample_sets=sample_sets)
-    assert tuple(df_v3_wild.columns) == expected_cols
-    assert len(df_v3_wild) == 2784
-
-    # check v3 is the same
-    sample_sets = "v3"
-    df_v3 = ag3.sample_cohorts(sample_sets=sample_sets)
-    pd.testing.assert_frame_equal(df_v3, df_v3_wild)
-
-    # test a single sample set
-    sample_sets = "AG1000G-UG"
-    df_UG = ag3.sample_cohorts(sample_sets=sample_sets)
-    assert df_UG.sample_id[0] == "AC0007-C"
-    assert df_UG.cohort_admin1_year[23] == "UG-E_2012_arab"
-    assert df_UG.cohort_admin1_month[37] == "UG-E_2012_10_arab"
-    assert df_UG.cohort_admin2_year[42] == "UG-E_Tororo_2012_arab"
-    assert df_UG.cohort_admin2_month[49] == "UG-E_Tororo_2012_10_arab"
-    assert df_UG.shape == (290, 5)
-
-    # test a list of sample sets
-    sample_sets = ["AG1000G-AO", "AG1000G-FR"]
-    df_list = ag3.sample_cohorts(sample_sets=sample_sets)
-    assert df_list.shape == (104, 5)
-    assert tuple(df_list.columns) == expected_cols
-    assert df_list.sample_id[0] == "AR0047-C"
-    assert df_list.sample_id[103] == "AP0017-Cx"
+    assert tuple(df_coh.columns) == expected_cols
+    if sample_sets == "v3":
+        assert len(df_coh) == 3081
+    if sample_sets == "v3_wild":
+        assert len(df_coh) == 2784
+    if sample_sets == "AG1000G-UG":
+        assert df_coh.sample_id[0] == "AC0007-C"
+        assert df_coh.cohort_admin1_year[23] == "UG-E_2012_arab"
+        assert df_coh.cohort_admin1_month[37] == "UG-E_2012_10_arab"
+        assert df_coh.cohort_admin2_year[42] == "UG-E_Tororo_2012_arab"
+        assert df_coh.cohort_admin2_month[49] == "UG-E_Tororo_2012_10_arab"
+        assert df_coh.shape == (290, 5)
+    if sample_sets == ["AG1000G-AO", "AG1000G-FR"]:
+        assert df_coh.shape == (104, 5)
+        assert df_coh.sample_id[0] == "AR0047-C"
+        assert df_coh.sample_id[103] == "AP0017-Cx"

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1184,3 +1184,11 @@ def test_sample_cohorts():
     assert df_UG.cohort_admin2_year[42] == "UG-E_Tororo_2012_arab"
     assert df_UG.cohort_admin2_month[49] == "UG-E_Tororo_2012_10_arab"
     assert df_UG.shape == (290, 5)
+
+    # test a list of sample sets
+    sample_sets = ["AG1000G-AO", "AG1000G-FR"]
+    df_list = ag3.sample_cohorts(sample_sets=sample_sets)
+    assert df_list.shape == (104, 5)
+    assert tuple(df_list.columns) == expected_cols
+    assert df_list.sample_id[0] == "AR0047-C"
+    assert df_list.sample_id[103] == "AP0017-Cx"

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1150,3 +1150,10 @@ def test_haplotypes(sample_sets, contig, analysis):
     assert isinstance(d1, xarray.DataArray)
     d2 = ds["call_genotype"].sum(axis=(1, 2))
     assert isinstance(d2, xarray.DataArray)
+
+
+def test_sample_cohorts(sample_sets="v3"):
+    ag3 = Ag3("gs://vo_agam_staging/")
+
+    df = ag3.sample_cohorts(sample_sets=sample_sets)
+    assert df.sample_set.unique() == "AG1000G-UG"

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1152,8 +1152,31 @@ def test_haplotypes(sample_sets, contig, analysis):
     assert isinstance(d2, xarray.DataArray)
 
 
-def test_sample_cohorts(sample_sets="v3"):
+# test v3 sample sets
+def test_sample_cohorts():
+    # TODO change staging to release once files copied over
+    expected_cols = (
+        "sample_id",
+        "cohort_admin1_year",
+        "cohort_admin1_month",
+        "cohort_admin2_year",
+        "cohort_admin2_month",
+        "sample_set",
+        "release",
+    )
+
     ag3 = Ag3("gs://vo_agam_staging/")
 
-    df = ag3.sample_cohorts(sample_sets=sample_sets)
-    assert df.sample_set.unique() == "AG1000G-UG"
+    # test v3 wild
+    sample_sets = "v3_wild"
+    df_v3_wild = ag3.sample_cohorts(sample_sets=sample_sets)
+    assert tuple(df_v3_wild.columns) == expected_cols
+    assert df_v3_wild.sample_set.unique()[-1] == "AG1000G-UG"
+    assert len(df_v3_wild) == 2784
+
+    # check v3 is the same
+    sample_sets = "v3"
+    df_v3 = ag3.sample_cohorts(sample_sets=sample_sets)
+    pd.testing.assert_frame_equal(df_v3, df_v3_wild)
+
+    # test a single sample set


### PR DESCRIPTION
resolves #51 

Adds a method `Ag3.sample_cohorts(sample_sets, analysis)` to access the Ag3 defined cohorts metadata. Tests have also been written for the method, but currently these point at the staging bucket. Once the metadata is copied to the release bucket, the tests should be updated.

