### PR TITLE
Support multiple releases via the sample_sets parameter

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -111,7 +111,7 @@ class Ag3:
         Returns
         -------
         df : pandas.DataFrame
-            A dataframe of sample sets.
+            A dataframe of sample sets, one row per sample set.
 
         """
 
@@ -138,7 +138,11 @@ class Ag3:
 
         elif isinstance(release, (list, tuple)):
             # multiple releases
-            df = pandas.concat([self.sample_sets(release=r) for r in release], axis=0)
+            df = pandas.concat(
+                [self.sample_sets(release=r) for r in release],
+                axis=0,
+                ignore_index=True,
+            )
             return df
 
         else:
@@ -231,6 +235,10 @@ class Ag3:
             # convenience, special case to exclude crosses
             sample_sets = self.v3_wild
 
+        elif sample_sets is None:
+            # all sample sets
+            sample_sets = self.sample_sets()["sample_set"].tolist()
+
         elif isinstance(sample_sets, str) and sample_sets.startswith("v3"):
             # convenience, can use a release identifier to denote all sample sets
             # in a release
@@ -280,12 +288,12 @@ class Ag3:
 
         return df
 
-    def sample_metadata(self, sample_sets="v3_wild", species_calls=("20200422", "aim")):
+    def sample_metadata(self, sample_sets=None, species_calls=("20200422", "aim")):
         """Access sample metadata for one or more sample sets.
 
         Parameters
         ----------
-        sample_sets : str or list of str
+        sample_sets : str or list of str, optional
             Can be a sample set identifier (e.g., "AG1000G-AO") or a list of sample set
             identifiers (e.g., ["AG1000G-BF-A", "AG1000G-BF-B"]) or a release identifier (e.g.,
             "v3") or a list of release identifiers.
@@ -295,6 +303,7 @@ class Ag3:
         Returns
         -------
         df : pandas.DataFrame
+            A dataframe of sample metadata, one row per sample.
 
         """
 
@@ -316,7 +325,7 @@ class Ag3:
                 self.sample_metadata(sample_sets=c, species_calls=species_calls)
                 for c in sample_sets
             ]
-            df = pandas.concat(dfs, axis=0, sort=False).reset_index(drop=True)
+            df = pandas.concat(dfs, axis=0, ignore_index=True)
 
         return df
 

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -529,7 +529,7 @@ class Ag3:
             return root
 
     def _snp_genotypes(self, *, contig, sample_set, field, inline_array, chunks):
-        # single single contig, single sample set
+        # single contig, single sample set
         root = self.open_snp_genotypes(sample_set=sample_set)
         z = root[contig]["calldata"][field]
         d = da_from_zarr(z, inline_array=inline_array, chunks=chunks)

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -714,13 +714,13 @@ class Ag3:
 
         return is_accessible
 
-    def _site_mask_ids(self, site_filters):
+    def _site_mask_ids(self, *, site_filters):
         if site_filters == "dt_20200416":
             return "gamb_colu_arab", "gamb_colu", "arab"
         else:
             raise ValueError
 
-    def _snp_df(self, transcript, site_filters="dt_20200416"):
+    def _snp_df(self, *, transcript, site_filters="dt_20200416"):
         """Set up a dataframe with SNP site and filter columns."""
 
         # get feature direct from geneset
@@ -809,7 +809,9 @@ class Ag3:
 
         return df_effects
 
-    def _prep_cohorts_arg(self, cohorts, sample_sets, species_calls, cohorts_analysis):
+    def _prep_cohorts_arg(
+        self, *, cohorts, sample_sets, species_calls, cohorts_analysis
+    ):
 
         # build cohort dictionary where key=cohort_id, value=loc_coh
         coh_dict = {}
@@ -1058,7 +1060,7 @@ class Ag3:
         return d
 
     def _snp_calls_dataset(
-        self, contig, sample_set, site_filters, inline_array, chunks
+        self, *, contig, sample_set, site_filters, inline_array, chunks
     ):
 
         coords = dict()
@@ -1233,7 +1235,7 @@ class Ag3:
             self._cache_cnv_hmm[sample_set] = root
         return root
 
-    def _cnv_hmm_dataset(self, contig, sample_set, inline_array, chunks):
+    def _cnv_hmm_dataset(self, *, contig, sample_set, inline_array, chunks):
 
         coords = dict()
         data_vars = dict()
@@ -1510,7 +1512,7 @@ class Ag3:
         return root
 
     def _cnv_discordant_read_calls_dataset(
-        self, contig, sample_set, inline_array, chunks
+        self, *, contig, sample_set, inline_array, chunks
     ):
 
         coords = dict()
@@ -1620,9 +1622,9 @@ class Ag3:
 
         # concatenate sample sets
         datasets = [
-            self.cnv_discordant_read_calls(
+            self._cnv_discordant_read_calls_dataset(
                 contig=contig,
-                sample_sets=s,
+                sample_set=s,
                 inline_array=inline_array,
                 chunks=chunks,
             )
@@ -1879,7 +1881,9 @@ class Ag3:
             self._cache_haplotype_sites[analysis] = root
         return root
 
-    def _haplotypes_dataset(self, contig, sample_set, analysis, inline_array, chunks):
+    def _haplotypes_dataset(
+        self, *, contig, sample_set, analysis, inline_array, chunks
+    ):
 
         # open zarr
         root = self.open_haplotypes(sample_set=sample_set, analysis=analysis)

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -865,8 +865,6 @@ def test_cnv_coverage_calls(sample_set, analysis, contig):
     assert isinstance(d2, xarray.DataArray)
 
 
-# TODO remove skip
-@pytest.mark.skip("temporarily skip until data problems resolved")
 @pytest.mark.parametrize(
     "sample_sets",
     [
@@ -958,8 +956,6 @@ def test_cnv_discordant_read_calls(sample_sets, contig):
     assert isinstance(d2, xarray.DataArray)
 
 
-# TODO remove skip
-@pytest.mark.skip("temporarily skip until data problems resolved")
 @pytest.mark.parametrize(
     "sample_sets",
     ["AG1000G-AO", ["AG1000G-AO", "AG1000G-UG"], "v3_wild", "v3", ["v3", "v3"], None],

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -57,7 +57,8 @@ def test_sample_sets(url):
     # test multiple releases
     df_multi = ag3.sample_sets(release=["v3", "v3"])
     assert_frame_equal(
-        df_multi, pd.concat([df_sample_sets_v3, df_sample_sets_v3], axis=0)
+        df_multi,
+        pd.concat([df_sample_sets_v3, df_sample_sets_v3], axis=0, ignore_index=True),
     )
 
 

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -31,13 +31,14 @@ def setup_ag3(url="simplecache::gs://vo_agam_release/", **storage_kwargs):
     return Ag3(url, **storage_kwargs)
 
 
+# TODO reinstate
 @pytest.mark.parametrize(
     "url",
     [
-        "gs://vo_agam_release/",
-        "gcs://vo_agam_release/",
-        "gs://vo_agam_release",
-        "gcs://vo_agam_release",
+        # "gs://vo_agam_release/",
+        # "gcs://vo_agam_release/",
+        # "gs://vo_agam_release",
+        # "gcs://vo_agam_release",
         "simplecache::gs://vo_agam_release/",
         "simplecache::gcs://vo_agam_release/",
     ],
@@ -865,6 +866,7 @@ def test_cnv_coverage_calls(sample_set, analysis, contig):
     assert isinstance(d2, xarray.DataArray)
 
 
+@pytest.mark.skip("temporary")  # TODO remove skip
 @pytest.mark.parametrize(
     "sample_sets",
     [
@@ -956,6 +958,7 @@ def test_cnv_discordant_read_calls(sample_sets, contig):
     assert isinstance(d2, xarray.DataArray)
 
 
+@pytest.mark.skip("temporary")  # TODO remove skip
 @pytest.mark.parametrize(
     "sample_sets",
     ["AG1000G-AO", ["AG1000G-AO", "AG1000G-UG"], "v3_wild", "v3", ["v3", "v3"], None],

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -179,13 +179,11 @@ def test_sample_metadata():
 )
 @pytest.mark.parametrize("method", ["aim", "pca"])
 def test_species_calls(sample_sets, method):
-
     ag3 = setup_ag3()
-    for method in "aim", "pca":
-        df_samples = ag3.sample_metadata(sample_sets=sample_sets, species_calls=None)
-        df_species = ag3.species_calls(sample_sets=sample_sets, method=method)
-        assert len(df_species) == len(df_samples)
-        assert set(df_species["species"].dropna()).difference(expected_species) == set()
+    df_samples = ag3.sample_metadata(sample_sets=sample_sets, species_calls=None)
+    df_species = ag3.species_calls(sample_sets=sample_sets, method=method)
+    assert len(df_species) == len(df_samples)
+    assert set(df_species["species"].dropna()).difference(expected_species) == set()
 
 
 @pytest.mark.parametrize("mask", ["gamb_colu_arab", "gamb_colu", "arab"])

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -54,6 +54,12 @@ def test_sample_sets(url):
     df_default = ag3.sample_sets()
     assert_frame_equal(df_sample_sets_v3, df_default)
 
+    # test multiple releases
+    df_multi = ag3.sample_sets(release=["v3", "v3"])
+    assert_frame_equal(
+        df_multi, pd.concat([df_sample_sets_v3, df_sample_sets_v3], axis=0)
+    )
+
 
 def test_sample_metadata():
 

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -111,9 +111,17 @@ def test_sample_metadata():
     expected_len = df_sample_sets_v3.loc[loc_sample_sets]["sample_count"].sum()
     assert len(df_samples_bf) == expected_len
 
+    # multiple releases
+    sample_sets = ["v3", "v3"]
+    df_samples_mr = ag3.sample_metadata(sample_sets=sample_sets, species_calls=None)
+    assert_frame_equal(
+        df_samples_mr,
+        pd.concat([df_samples_v3, df_samples_v3], axis=0, ignore_index=True),
+    )
+
     # default is v3_wild
     df_default = ag3.sample_metadata(species_calls=None)
-    assert_frame_equal(df_samples_v3_wild, df_default)
+    assert_frame_equal(df_samples_v3, df_default)
 
     aim_cols = (
         "aim_fraction_colu",
@@ -126,14 +134,14 @@ def test_sample_metadata():
     # AIM species calls, included by default
     df_samples_aim = ag3.sample_metadata()
     assert tuple(df_samples_aim.columns) == expected_cols + aim_cols
-    assert len(df_samples_aim) == len(df_samples_v3_wild)
-    assert set(df_samples_aim["species"]) == expected_species
+    assert len(df_samples_aim) == len(df_samples_v3)
+    assert set(df_samples_aim["species"].dropna()) == expected_species
 
     # AIM species calls, explicit
     df_samples_aim = ag3.sample_metadata(species_calls=("20200422", "aim"))
     assert tuple(df_samples_aim.columns) == expected_cols + aim_cols
-    assert len(df_samples_aim) == len(df_samples_v3_wild)
-    assert set(df_samples_aim["species"]) == expected_species
+    assert len(df_samples_aim) == len(df_samples_v3)
+    assert set(df_samples_aim["species"].dropna()) == expected_species
 
     pca_cols = (
         "PC1",
@@ -146,8 +154,8 @@ def test_sample_metadata():
     # PCA species calls
     df_samples_pca = ag3.sample_metadata(species_calls=("20200422", "pca"))
     assert tuple(df_samples_pca.columns) == expected_cols + pca_cols
-    assert len(df_samples_pca) == len(df_samples_v3_wild)
-    assert set(df_samples_pca["species"]).difference(expected_species) == set()
+    assert len(df_samples_pca) == len(df_samples_v3)
+    assert set(df_samples_pca["species"].dropna()).difference(expected_species) == set()
 
 
 def test_species_calls():

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -31,14 +31,13 @@ def setup_ag3(url="simplecache::gs://vo_agam_release/", **storage_kwargs):
     return Ag3(url, **storage_kwargs)
 
 
-# TODO reinstate
 @pytest.mark.parametrize(
     "url",
     [
-        # "gs://vo_agam_release/",
-        # "gcs://vo_agam_release/",
-        # "gs://vo_agam_release",
-        # "gcs://vo_agam_release",
+        "gs://vo_agam_release/",
+        "gcs://vo_agam_release/",
+        "gs://vo_agam_release",
+        "gcs://vo_agam_release",
         "simplecache::gs://vo_agam_release/",
         "simplecache::gcs://vo_agam_release/",
     ],
@@ -312,6 +311,30 @@ def test_snp_genotypes(chunks, sample_sets, contig):
     assert gt_pass.shape[0] == np.count_nonzero(filter_pass)
     assert gt_pass.shape[1] == len(df_samples)
     assert gt_pass.shape[2] == 2
+
+
+@pytest.mark.parametrize(
+    "sample_sets",
+    ["AG1000G-X", ["AG1000G-BF-A", "AG1000G-BF-B"], "v3", "v3_wild", ["v3", "v3"]],
+)
+@pytest.mark.parametrize("contig", ["X", ["3R", "3L"]])
+def test_snp_genotypes_chunks(sample_sets, contig):
+
+    ag3 = setup_ag3()
+    gt_native = ag3.snp_genotypes(
+        contig=contig, sample_sets=sample_sets, chunks="native"
+    )
+    gt_auto = ag3.snp_genotypes(contig=contig, sample_sets=sample_sets, chunks="auto")
+    gt_manual = ag3.snp_genotypes(
+        contig=contig, sample_sets=sample_sets, chunks=(100_000, 10, 2)
+    )
+
+    assert gt_native.chunks != gt_auto.chunks
+    assert gt_auto.chunks != gt_manual.chunks
+    assert gt_manual.chunks != gt_native.chunks
+    assert gt_manual.chunks[0][0] == 100_000
+    assert gt_manual.chunks[1][0] == 10
+    assert gt_manual.chunks[2][0] == 2
 
 
 def test_genome():
@@ -866,7 +889,6 @@ def test_cnv_coverage_calls(sample_set, analysis, contig):
     assert isinstance(d2, xarray.DataArray)
 
 
-@pytest.mark.skip("temporary")  # TODO remove skip
 @pytest.mark.parametrize(
     "sample_sets",
     [
@@ -958,7 +980,6 @@ def test_cnv_discordant_read_calls(sample_sets, contig):
     assert isinstance(d2, xarray.DataArray)
 
 
-@pytest.mark.skip("temporary")  # TODO remove skip
 @pytest.mark.parametrize(
     "sample_sets",
     ["AG1000G-AO", ["AG1000G-AO", "AG1000G-UG"], "v3_wild", "v3", ["v3", "v3"], None],


### PR DESCRIPTION
This PR makes some changes to how the `sample_sets` parameter is handled. In particular:

* Make sure that multiple releases can be requested via all functions that support a `sample_sets` parameter.
* Change the default behaviour of these functions so that data from all samples sets from all available releases are returned by default.

Note that this second point makes a subtle change to how the API behaves. When interacting with public releases, this will currently be equivalent to requesting `sample_sets="v3"`. When accessing pre-releases, this will access everything from v3 to v3.5. The rationale here is that, generally, this change should mean that users can forget about the `sample_sets` parameter for most use cases, which will hopefully make things a little simpler.

Resolves #85. Resolves #86.