### PR TITLE
Add "frq_" to columns in frequency generating methods

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -1178,7 +1178,7 @@ class Ag3:
             if n_samples == 0:
                 raise ValueError(f"no samples for cohort {coh!r}")
             if n_samples < min_cohort_size:
-                freq_cols[coh] = np.nan
+                freq_cols["frq_" + coh] = np.nan
             else:
                 gt_coh = np.compress(loc_coh, gt, axis=1)
                 # count alleles
@@ -1186,7 +1186,7 @@ class Ag3:
                 # compute allele frequencies
                 af_coh = ac_coh.to_frequencies()
                 # add column to dict
-                freq_cols[coh] = af_coh[:, 1:].flatten()
+                freq_cols["frq_" + coh] = af_coh[:, 1:].flatten()
 
         # build a dataframe with the frequency columns
         df_freqs = pandas.DataFrame(freq_cols)
@@ -1200,7 +1200,7 @@ class Ag3:
             [
                 df_snps,
                 pandas.DataFrame(
-                    {"max_af": df_snps[list(coh_dict.keys())].max(axis=1)}
+                    {"max_af": df_snps[list(freq_cols.keys())].max(axis=1)}
                 ),
             ],
             axis=1,

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -2109,8 +2109,8 @@ class Ag3:
             if n_samples == 0:
                 raise ValueError(f"no samples for cohort {coh!r}")
             if n_samples < min_cohort_size:
-                freq_cols[f"{coh}_amp"] = np.nan
-                freq_cols[f"{coh}_del"] = np.nan
+                freq_cols[f"frq_{coh}_amp"] = np.nan
+                freq_cols[f"frq_{coh}_del"] = np.nan
             else:
                 is_amp_coh = np.compress(loc_samples, is_amp, axis=1)
                 is_del_coh = np.compress(loc_samples, is_del, axis=1)
@@ -2118,8 +2118,8 @@ class Ag3:
                 del_count_coh = np.sum(is_del_coh, axis=1)
                 amp_freq_coh = amp_count_coh / n_samples
                 del_freq_coh = del_count_coh / n_samples
-                freq_cols[f"{coh}_amp"] = amp_freq_coh
-                freq_cols[f"{coh}_del"] = del_freq_coh
+                freq_cols[f"frq_{coh}_amp"] = amp_freq_coh
+                freq_cols[f"frq_{coh}_del"] = del_freq_coh
 
         # build a dataframe with the frequency columns
         df_freqs = pandas.DataFrame(freq_cols)

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -744,7 +744,8 @@ def test_snp_allele_frequencies__str_cohorts():
     df_coh = ag3.sample_cohorts(sample_sets="3.0", cohorts_analysis="20211101")
     coh_nm = "cohort_" + cohorts
     all_cohort_labels = df_coh[coh_nm].dropna().unique().tolist()
-    expected_fields = universal_fields + all_cohort_labels + ["max_af"]
+    frq_cohort_labels = ["frq_" + s for s in all_cohort_labels]
+    expected_fields = universal_fields + frq_cohort_labels + ["max_af"]
 
     assert df.columns.tolist() == expected_fields
     assert isinstance(df, pd.DataFrame)
@@ -778,14 +779,15 @@ def test_snp_allele_frequencies__dict_cohorts():
     )
 
     assert isinstance(df, pd.DataFrame)
-    expected_fields = universal_fields + list(cohorts.keys()) + ["max_af"]
+    frq_columns = ["frq_" + s for s in list(cohorts.keys())]
+    expected_fields = universal_fields + frq_columns + ["max_af"]
     assert df.columns.tolist() == expected_fields
     assert df.shape == (133, len(expected_fields))
     assert df.iloc[0].position == 28597653
     assert df.iloc[1].ref_allele == "A"
     assert df.iloc[2].alt_allele == "C"
-    assert df.iloc[3].ke == 0
-    assert df.iloc[4].bf_2012_col == pytest.approx(0.006097, abs=1e-6)
+    assert df.iloc[3].frq_ke == 0
+    assert df.iloc[4].frq_bf_2012_col == pytest.approx(0.006097, abs=1e-6)
     assert df.iloc[4].max_af == pytest.approx(0.006097, abs=1e-6)
     # check invariant have been dropped
     assert df.max_af.min() > 0
@@ -841,7 +843,8 @@ def test_snp_allele_frequencies__str_cohorts__effects():
     df_coh = ag3.sample_cohorts(sample_sets="3.0", cohorts_analysis="20211101")
     coh_nm = "cohort_" + cohorts
     all_cohort_labels = df_coh[coh_nm].dropna().unique().tolist()
-    expected_fields = universal_fields + all_cohort_labels + ["max_af"] + effects_fields
+    frq_cohort_labels = ["frq_" + s for s in all_cohort_labels]
+    expected_fields = universal_fields + frq_cohort_labels + ["max_af"] + effects_fields
 
     assert isinstance(df, pd.DataFrame)
     assert len(df) == 16526

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1261,11 +1261,11 @@ def test_gene_cnv_frequencies(contig, cohorts):
         # sanity checks
         cohort_labels = None
         if isinstance(cohorts, dict):
-            cohort_labels = cohorts.keys()
+            cohort_labels = ["frq_" + s for s in cohorts.keys()]
         if isinstance(cohorts, str):
             df_coh = ag3.sample_cohorts(sample_sets="3.0", cohorts_analysis="20211101")
             coh_nm = "cohort_" + cohorts
-            cohort_labels = list(df_coh[coh_nm].dropna().unique())
+            cohort_labels = ["frq_" + s for s in list(df_coh[coh_nm].dropna().unique())]
 
         suffixes = ["_amp", "_del"]
         cnv_freq_cols = [a + b for a in cohort_labels for b in suffixes]


### PR DESCRIPTION
resolves #116 

Adds "frqs_" string to the start of each frequency column name in dataframes produces via `snp_allele_frequencies()` and `cnv_gene_frequencies()`. Updates tests.