### PR TITLE
`ag3.aa_allele_frequencies()` method

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -1163,8 +1163,7 @@ class Ag3:
 
         Notes
         -----
-        NaNs will be returned for any cohorts with fewer samples than min_cohort_size,
-        these can be removed from the output dataframe using pandas df.dropna(axis='columns').
+        Cohorts with fewer samples than min_cohort_size will be excluded from output.
 
         """
 
@@ -2444,8 +2443,7 @@ class Ag3:
 
         Notes
         -----
-        NaNs will be returned for any cohorts with fewer samples than min_cohort_size,
-        these can be removed from the output dataframe using pandas df.dropna(axis='columns').
+        Cohorts with fewer samples than min_cohort_size will be excluded from output.
 
         """
 

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -2461,7 +2461,9 @@ class Ag3:
         )
 
         # we just want aa change
-        df_ns_snps = df_snps.query("effect == 'NON_SYNONYMOUS_CODING'").copy()
+        df_ns_snps = df_snps.query(
+            "effect in ['NON_SYNONYMOUS_CODING', 'START_LOST', 'STOP_LOST', 'STOP_GAINED']"
+        ).copy()
 
         # group and sum to collapse multi variant allele changes
         df_aaf = df_ns_snps.groupby(["aa_pos", "aa_change"]).sum().reset_index()

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -2395,6 +2395,26 @@ class Ag3:
 
         return df
 
+    def aa_frequencies(self, df):
+        """Compute frequencies of amino acid substitutions from snp allele frequencies.
+        Where multiple snp changes cause identical amino acid substitutions, frequencies
+        are summed.
+
+        Parameters
+        ----------
+        df : pandas.Dataframe from ag3.snp_allele_frequencies()
+            Input dataframe must contain "aa_pos", "aa_change" and "frq..." columns, as output
+            from the ag3.snp_allele_frequencies() method.
+
+        Returns
+        -------
+        df : pandas.DataFrame
+
+        """
+
+        df_aaf = df.groupby(["aa_pos", "aa_change"]).sum().reset_index()
+        return df_aaf
+
 
 @numba.njit("Tuple((int8, int64))(int8[:], int8)")
 def _cn_mode_1d(a, vmax):

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1495,5 +1495,5 @@ def test_aa_frequencies():
 
     assert sorted(df.columns.tolist()) == sorted(expected_fields)
     assert isinstance(df, pd.DataFrame)
-    assert df.shape == (57, 6)
+    assert df.shape == (61, 6)
     assert df.loc["V402L"].max_af == pytest.approx(0.121951, abs=1e-6)

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1474,6 +1474,14 @@ def test_aa_frequencies():
     cohorts = "admin1_year"
     min_cohort_size = 10
     sample_sets = ("AG1000G-BF-A", "AG1000G-BF-B", "AG1000G-BF-C")
+    expected_fields = [
+        "frq_BF-09_gamb_2012",
+        "frq_BF-09_colu_2012",
+        "frq_BF-09_colu_2014",
+        "frq_BF-09_gamb_2014",
+        "frq_BF-07_gamb_2004",
+        "max_af",
+    ]
 
     df = ag3.aa_allele_frequencies(
         transcript="AGAP004707-RD",
@@ -1484,13 +1492,8 @@ def test_aa_frequencies():
         sample_sets=sample_sets,
         drop_invariant=True,
     )
-    # df_coh = ag3.sample_cohorts(sample_sets="3.0", cohorts_analysis="20211101")
-    # coh_nm = "cohort_" + cohorts
-    # coh_counts = df_coh[coh_nm].dropna().value_counts().to_frame()
-    # cohort_labels = coh_counts[coh_counts[coh_nm] >= min_cohort_size].index.to_list()
-    # frq_cohort_labels = ["frq_" + s for s in cohort_labels]
-    # expected_fields = universal_fields + frq_cohort_labels + ["max_af"]
 
-    # assert sorted(df.columns.tolist()) == sorted(expected_fields)
+    assert sorted(df.columns.tolist()) == sorted(expected_fields)
     assert isinstance(df, pd.DataFrame)
-    # assert df.shape == (16526, 68)
+    assert df.shape == (57, 6)
+    assert df.loc["V402L"].max_af == pytest.approx(0.121951, abs=1e-6)

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1471,24 +1471,26 @@ def test_locate_region(region_raw):
 
 def test_aa_frequencies():
     ag3 = setup_ag3()
-    gene = "AGAP004707"
-    transcript = f"{gene}-RD"
-    cohort = "admin1_year"
-    min_af = 0.05
+    cohorts = "admin1_year"
+    min_cohort_size = 10
+    sample_sets = ("AG1000G-BF-A", "AG1000G-BF-B", "AG1000G-BF-C")
 
-    df_snp_af = ag3.snp_allele_frequencies(
-        transcript=transcript,
-        cohorts=cohort,
-        min_cohort_size=10,
-        sample_sets=("AG1000G-BF-A", "AG1000G-BF-B", "AG1000G-BF-C"),
+    df = ag3.aa_allele_frequencies(
+        transcript="AGAP004707-RD",
+        cohorts=cohorts,
+        cohorts_analysis="20211101",
+        min_cohort_size=min_cohort_size,
+        site_mask="gamb_colu",
+        sample_sets=sample_sets,
+        drop_invariant=True,
     )
+    # df_coh = ag3.sample_cohorts(sample_sets="3.0", cohorts_analysis="20211101")
+    # coh_nm = "cohort_" + cohorts
+    # coh_counts = df_coh[coh_nm].dropna().value_counts().to_frame()
+    # cohort_labels = coh_counts[coh_counts[coh_nm] >= min_cohort_size].index.to_list()
+    # frq_cohort_labels = ["frq_" + s for s in cohort_labels]
+    # expected_fields = universal_fields + frq_cohort_labels + ["max_af"]
 
-    df_snps = df_snp_af.query(
-        f"effect == 'NON_SYNONYMOUS_CODING' and max_af > {min_af}"
-    )
-
-    df_aaf = ag3.aa_frequencies(df_snps)
-
-    assert isinstance(df_aaf, pd.DataFrame)
-    assert len(df_aaf) == len(df_snps) - 1
-    assert df_aaf.aa_change.is_unique
+    # assert sorted(df.columns.tolist()) == sorted(expected_fields)
+    assert isinstance(df, pd.DataFrame)
+    # assert df.shape == (16526, 68)

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1467,3 +1467,28 @@ def test_locate_region(region_raw):
         assert region == Region("2R", 48714463, 48715355)
     if region_raw == "2L:24,630,355-24,633,221":
         assert region == Region("2L", 24630355, 24633221)
+
+
+def test_aa_frequencies():
+    ag3 = setup_ag3()
+    gene = "AGAP004707"
+    transcript = f"{gene}-RD"
+    cohort = "admin1_year"
+    min_af = 0.05
+
+    df_snp_af = ag3.snp_allele_frequencies(
+        transcript=transcript,
+        cohorts=cohort,
+        min_cohort_size=10,
+        sample_sets=("AG1000G-BF-A", "AG1000G-BF-B", "AG1000G-BF-C"),
+    )
+
+    df_snps = df_snp_af.query(
+        f"effect == 'NON_SYNONYMOUS_CODING' and max_af > {min_af}"
+    )
+
+    df_aaf = ag3.aa_frequencies(df_snps)
+
+    assert isinstance(df_aaf, pd.DataFrame)
+    assert len(df_aaf) == len(df_snps) - 1
+    assert df_aaf.aa_change.is_unique


### PR DESCRIPTION
resolves #101 

Adds a method which is similar to `snp_allele_frequencies()` except it collapses multi-variant aa-changes and drops unneeded columns.