### PR TITLE
Add sample coverage variance filtering to CNV frequencies methods

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -1170,6 +1170,9 @@ class Ag3:
 
         """
 
+        # check parameters
+        _check_param_min_cohort_size(min_cohort_size)
+
         # handle sample_query
         loc_samples = None
         if sample_query is not None:
@@ -2133,22 +2136,22 @@ class Ag3:
             If a string, gives the name of a predefined cohort set, e.g., one of
             {"admin1_month", "admin1_year", "admin2_month", "admin2_year"}.
             If a dict, should map cohort labels to sample queries, e.g.,
-            `{"bf_2012_col": "country == 'Burkina Faso' and year == 2012 and taxon == 'coluzzii'"}`.
+            `{"bf_2012_col": "country == 'Burkina Faso' and year == 2012 and
+            taxon == 'coluzzii'"}`.
         sample_query : str, optional
-            A pandas query string which will be evaluated against the sample metadata e.g.,
-            "taxon == 'coluzzii' and country == 'Burkina Faso'".
+            A pandas query string which will be evaluated against the sample
+            metadata e.g., "taxon == 'coluzzii' and country == 'Burkina Faso'".
         cohorts_analysis : str
-            Cohort analysis identifier (date of analysis), default is latest version.
+            Cohort analysis identifier (date of analysis), default is the latest
+            version.
         min_cohort_size : int
-            Minimum cohort size, below which allele frequencies are not calculated for cohorts.
-            Please note, NaNs will be returned for any cohorts with fewer samples than min_cohort_size,
-            these can be removed from the output dataframe using pandas df.dropna(axis='columns').
+            Minimum cohort size, below which cohorts are dropped.
         species_analysis : {"aim_20200422", "pca_20200422"}, optional
             Include species calls in metadata.
         sample_sets : str or list of str, optional
-            Can be a sample set identifier (e.g., "AG1000G-AO") or a list of sample set
-            identifiers (e.g., ["AG1000G-BF-A", "AG1000G-BF-B"]) or a release identifier (e.g.,
-            "3.0") or a list of release identifiers.
+            Can be a sample set identifier (e.g., "AG1000G-AO") or a list of
+            sample set identifiers (e.g., ["AG1000G-BF-A", "AG1000G-BF-B"]) or a
+            release identifier (e.g., "3.0") or a list of release identifiers.
         drop_invariant : bool, optional
             If True, drop any rows where there is no evidence of variation.
         max_coverage_variance : float, optional
@@ -2161,6 +2164,9 @@ class Ag3:
             one row per gene and CNV type (amp/del).
 
         """
+
+        # check parameters
+        _check_param_min_cohort_size(min_cohort_size)
 
         # load sample metadata
         df_samples = self.sample_metadata(
@@ -2824,6 +2830,9 @@ class Ag3:
 
         """
 
+        # check parameters
+        _check_param_min_cohort_size(min_cohort_size)
+
         # load sample metadata
         df_samples = self.sample_metadata(
             sample_sets=sample_sets,
@@ -3209,6 +3218,9 @@ class Ag3:
             calculations.
 
         """
+
+        # check parameters
+        _check_param_min_cohort_size(min_cohort_size)
 
         # load sample metadata
         df_samples = self.sample_metadata(
@@ -3832,3 +3844,14 @@ def _build_cohorts_from_sample_grouping(group_samples_by_cohort, min_cohort_size
     df_cohorts = df_cohorts.query(f"size >= {min_cohort_size}").reset_index(drop=True)
 
     return df_cohorts
+
+
+def _check_param_min_cohort_size(min_cohort_size):
+    if not isinstance(min_cohort_size, int):
+        raise TypeError(
+            f"Type of parameter min_cohort_size must be int; found {type(min_cohort_size)}."
+        )
+    if min_cohort_size < 1:
+        raise ValueError(
+            f"Value of parameter min_cohort_size must be at least 1; found {min_cohort_size}."
+        )

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -2848,7 +2848,7 @@ class Ag3:
             loc_samples = df_samples.eval(sample_query).values
 
         # filter samples
-        if sample_query is not None:
+        if loc_samples is not None:
             df_samples = df_samples.loc[loc_samples].reset_index(drop=True).copy()
             gt = da.compress(loc_samples, gt, axis=1)
 

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1294,8 +1294,9 @@ def test_gene_cnv_frequencies(contig, cohorts):
         contig=contig,
         sample_sets="3.0",
         cohorts=cohorts,
-        min_cohort_size=0,
+        min_cohort_size=1,
         drop_invariant=False,
+        max_coverage_variance=None,
     )
 
     assert isinstance(df_cnv_frq, pd.DataFrame)
@@ -1314,8 +1315,8 @@ def test_gene_cnv_frequencies(contig, cohorts):
     # check frequencies are within sensible range
     for f in frq_cols:
         x = df_cnv_frq[f].values
-        assert np.all(x >= 0)
-        assert np.all(x <= 1)
+        assert np.all(x >= 0), f
+        assert np.all(x <= 1), f
 
     # check amp and del frequencies are within sensible range
     df_frq_amp = df_cnv_frq[frq_cols].xs("amp", level="cnv_type")

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1171,6 +1171,8 @@ def test_gene_cnv(contig, sample_sets):
         "gene_windows",
         "gene_name",
         "gene_strand",
+        "sample_coverage_variance",
+        "sample_is_high_variance",
     }
     assert set(ds.data_vars) == expected_data_vars
 
@@ -1355,6 +1357,62 @@ def test_gene_cnv_frequencies__query():
     assert isinstance(df, pd.DataFrame)
     assert sorted(df.columns) == sorted(expected_columns)
     df_genes = ag3.geneset().query(f"type == 'gene' and contig == '{contig}'")
+    assert len(df) == len(df_genes) * 2
+
+
+def test_gene_cnv_frequencies__max_coverage_variance():
+
+    ag3 = setup_ag3()
+    contig = "3L"
+    df_genes = ag3.geneset().query(f"type == 'gene' and contig == '{contig}'")
+
+    base_columns = [
+        "contig",
+        "start",
+        "end",
+        "windows",
+        "max_af",
+        "gene_strand",
+        "gene_description",
+    ]
+
+    # run without a threshold on coverage variance
+    df = ag3.gene_cnv_frequencies(
+        contig=contig,
+        sample_sets=["AG1000G-GM-A", "AG1000G-GM-B", "AG1000G-GM-C"],
+        cohorts="admin1_year",
+        min_cohort_size=10,
+        max_coverage_variance=None,
+        drop_invariant=False,
+    )
+    expected_frq_columns = [
+        "frq_GM-L_gcx2_2012",
+        "frq_GM-M_gcx2_2012",
+        "frq_GM-N_gcx1_2011",
+    ]
+    expected_columns = base_columns + expected_frq_columns
+    assert isinstance(df, pd.DataFrame)
+    assert sorted(df.columns) == sorted(expected_columns)
+    assert len(df) == len(df_genes) * 2
+
+    # Run with a threshold on coverage variance - this will remove samples,
+    # which in turn will drop one of the cohorts below the min_cohort_size,
+    # and so we can check that we have lost a cohort.
+    df = ag3.gene_cnv_frequencies(
+        contig=contig,
+        sample_sets=["AG1000G-GM-A", "AG1000G-GM-B", "AG1000G-GM-C"],
+        cohorts="admin1_year",
+        min_cohort_size=10,
+        max_coverage_variance=0.2,
+        drop_invariant=False,
+    )
+    expected_frq_columns = [
+        "frq_GM-M_gcx2_2012",
+        "frq_GM-N_gcx1_2011",
+    ]
+    expected_columns = base_columns + expected_frq_columns
+    assert isinstance(df, pd.DataFrame)
+    assert sorted(df.columns) == sorted(expected_columns)
     assert len(df) == len(df_genes) * 2
 
 
@@ -2029,6 +2087,7 @@ def _check_gene_cnv_frequencies_advanced(
     min_cohort_size=10,
     variant_query="max_af > 0.02",
     drop_invariant=True,
+    max_coverage_variance=0.2,
 ):
 
     ag3 = setup_ag3()
@@ -2042,6 +2101,7 @@ def _check_gene_cnv_frequencies_advanced(
         min_cohort_size=min_cohort_size,
         variant_query=variant_query,
         drop_invariant=drop_invariant,
+        max_coverage_variance=max_coverage_variance,
     )
 
     assert isinstance(ds, xr.Dataset)
@@ -2143,6 +2203,7 @@ def _check_gene_cnv_frequencies_advanced(
             sample_query=sample_query,
             min_cohort_size=min_cohort_size,
             drop_invariant=drop_invariant,
+            max_coverage_variance=max_coverage_variance,
         )
         df_af = df_af.reset_index()  # make sure all variables available to check
         if variant_query is not None:
@@ -2248,6 +2309,17 @@ def test_gene_cnv_frequencies_advanced__drop_invariant(drop_invariant):
     _check_gene_cnv_frequencies_advanced(
         variant_query=None,
         drop_invariant=drop_invariant,
+    )
+
+
+@pytest.mark.parametrize(
+    "max_coverage_variance",
+    [None, 0.2],
+)
+def test_gene_cnv_frequencies_advanced__max_coverage_variance(max_coverage_variance):
+    _check_gene_cnv_frequencies_advanced(
+        max_coverage_variance=max_coverage_variance,
+        sample_sets=["AG1000G-GM-A", "AG1000G-GM-B", "AG1000G-GM-C"],
     )
 
 


### PR DESCRIPTION
Adds a `max_coverage_variance` parameter to the CNV frequencies methods, which defaults to the value we normally use for filtering out samples with too noisy HMM CNV data.

* Resolves #128. 
* Resolves #141.