### PR TITLE
Add support for multiple contigs to Ag3 gene_cnv... functions

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -2242,47 +2242,6 @@ class Ag3:
         # check parameters
         _check_param_min_cohort_size(min_cohort_size)
 
-        # handle multiple contigs
-        if isinstance(contig, str):
-            contig = [contig]
-
-        # concatenate data from multiple contigs
-        df = pd.concat(
-            [
-                self._gene_cnv_frequencies(
-                    contig=c,
-                    cohorts=cohorts,
-                    sample_query=sample_query,
-                    cohorts_analysis=cohorts_analysis,
-                    min_cohort_size=min_cohort_size,
-                    species_analysis=species_analysis,
-                    sample_sets=sample_sets,
-                    drop_invariant=drop_invariant,
-                    max_coverage_variance=max_coverage_variance,
-                )
-                for c in contig
-            ]
-        )
-
-        return df
-
-    def _gene_cnv_frequencies(
-        self,
-        *,
-        contig,
-        cohorts,
-        sample_query,
-        cohorts_analysis,
-        min_cohort_size,
-        species_analysis,
-        sample_sets,
-        drop_invariant,
-        max_coverage_variance,
-    ):
-
-        # sanity check - here we handle one contig at a time
-        assert isinstance(contig, str)
-
         # load sample metadata
         df_samples = self.sample_metadata(
             sample_sets=sample_sets,

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -2183,7 +2183,7 @@ class Ag3:
 
         Parameters
         ----------
-        contig : str
+        contig : str or list of str
             Chromosome arm, e.g., "3R".
         cohorts : str or dict
             If a string, gives the name of a predefined cohort set, e.g., one of
@@ -2220,6 +2220,47 @@ class Ag3:
 
         # check parameters
         _check_param_min_cohort_size(min_cohort_size)
+
+        # handle multiple contigs
+        if isinstance(contig, str):
+            contig = [contig]
+
+        # concatenate data from multiple contigs
+        df = pd.concat(
+            [
+                self._gene_cnv_frequencies(
+                    contig=c,
+                    cohorts=cohorts,
+                    sample_query=sample_query,
+                    cohorts_analysis=cohorts_analysis,
+                    min_cohort_size=min_cohort_size,
+                    species_analysis=species_analysis,
+                    sample_sets=sample_sets,
+                    drop_invariant=drop_invariant,
+                    max_coverage_variance=max_coverage_variance,
+                )
+                for c in contig
+            ]
+        )
+
+        return df
+
+    def _gene_cnv_frequencies(
+        self,
+        *,
+        contig,
+        cohorts,
+        sample_query,
+        cohorts_analysis,
+        min_cohort_size,
+        species_analysis,
+        sample_sets,
+        drop_invariant,
+        max_coverage_variance,
+    ):
+
+        # sanity check - here we handle one contig at a time
+        assert isinstance(contig, str)
 
         # load sample metadata
         df_samples = self.sample_metadata(

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1173,7 +1173,7 @@ def test_cn_mode(rows, cols, vmax):
     "sample_sets",
     ["AG1000G-AO", ("AG1000G-TZ", "AG1000G-UG"), "3.0", None],
 )
-@pytest.mark.parametrize("contig", ["2R", "X"])
+@pytest.mark.parametrize("contig", ["2R", "X", ["2R", "3R"]])
 def test_gene_cnv(contig, sample_sets):
     ag3 = setup_ag3()
 
@@ -1186,7 +1186,11 @@ def test_gene_cnv(contig, sample_sets):
         "CN_mode",
         "CN_mode_count",
         "gene_windows",
+        "gene_contig",
+        "gene_start",
+        "gene_end",
         "gene_name",
+        "gene_description",
         "gene_strand",
         "sample_coverage_variance",
         "sample_is_high_variance",
@@ -1195,8 +1199,6 @@ def test_gene_cnv(contig, sample_sets):
 
     expected_coords = {
         "gene_id",
-        "gene_start",
-        "gene_end",
         "sample_id",
     }
     assert set(ds.coords) == expected_coords
@@ -1209,7 +1211,12 @@ def test_gene_cnv(contig, sample_sets):
     n_samples = len(df_samples)
     assert ds.dims["samples"] == n_samples
     df_geneset = ag3.geneset()
-    df_genes = df_geneset.query(f"type == 'gene' and contig == '{contig}'")
+    if isinstance(contig, str):
+        df_genes = df_geneset.query(f"type == 'gene' and contig == '{contig}'")
+    else:
+        df_genes = pd.concat(
+            [df_geneset.query(f"type == 'gene' and contig == '{c}'") for c in contig]
+        )
     n_genes = len(df_genes)
     assert ds.dims["genes"] == n_genes
 

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1282,7 +1282,7 @@ def test_gene_cnv_xarray_indexing(contig, sample_sets):
     assert set(o.dims) == set()
 
 
-@pytest.mark.parametrize("contig", ["2R", "X"])
+@pytest.mark.parametrize("contig", ["2R", "X", ["2R", "3R"]])
 @pytest.mark.parametrize(
     "cohorts",
     [
@@ -1306,7 +1306,12 @@ def test_gene_cnv_frequencies(contig, cohorts):
         "label",
     ]
     ag3 = setup_ag3()
-    df_genes = ag3.geneset().query(f"type == 'gene' and contig == '{contig}'")
+    if isinstance(contig, str):
+        df_genes = ag3.geneset().query(f"type == 'gene' and contig == '{contig}'")
+    else:
+        df_genes = pd.concat(
+            [ag3.geneset().query(f"type == 'gene' and contig == '{c}'") for c in contig]
+        )
 
     df_cnv_frq = ag3.gene_cnv_frequencies(
         contig=contig,


### PR DESCRIPTION
Add support for contig parameter being a list of contigs to `Ag3.gene_cnv()` and `Ag3.gene_cnv_frequencies()`.

Resolves #162.