### PR TITLE
igv-notebook as optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ from the following locations:
 ## Release notes
 
 
+### 4.0.1
+
+* Make igv-notebook an optional dependency while it is still only
+  available from GitHub.
+
+
 ### 4.0.0
 
 * `Ag3`: A new `pca()` function has been added for performing

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -4881,7 +4881,25 @@ class Ag3:
     @staticmethod
     def igv(region):
 
-        import igv_notebook
+        try:
+            # The igv-notebook package is not currently available from PyPI so
+            # we cannot have this as an automatically installed dependency yet.
+            # So for the time being, provide a message to the user with
+            # information about how to install.
+            import igv_notebook
+        except ImportError:
+            # re-raise with a more helpful message
+            raise ImportError(
+                dedent(
+                    """
+                This function requires the igv-notebook package to be installed.
+                Please install this package by running the following system
+                command:
+
+                pip install git+https://github.com/igvteam/igv-notebook.git
+            """
+                )
+            )
 
         igv_notebook.init()
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -613,7 +613,7 @@ python-versions = ">=3.5"
 name = "igv-notebook"
 version = "0.1.0"
 description = "Package for embedding the juicebox.js genome visualization in IPython notebooks"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 develop = false
@@ -1982,7 +1982,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.10"
-content-hash = "42388488d7792c26c4756df26f19f176bfd99c343a230b9511a7ccd9e58ca1bd"
+content-hash = "396638e8738562f565bfca8feac23b7133cb7bbd31c70b73ab2b700d1439bfc2"
 
 [metadata.files]
 aiohttp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "malariagen_data"
-version = "4.0.0"
+version = "4.0.1"
 description = "A package for accessing and analysing MalariaGEN data."
 authors = [
     "Alistair Miles <alistair.miles@sanger.ac.uk>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ statsmodels = "*"
 ipyleaflet = "*"
 ipywidgets = "*"
 importlib_metadata = "*"
-igv-notebook = {git="https://github.com/igvteam/igv-notebook.git", branch="main"}
 ipinfo = "*"
 
 [tool.poetry.dev-dependencies]
@@ -43,6 +42,7 @@ jupyterlab = "*"
 pre-commit = "*"
 black = "*"
 snakeviz = "*"
+igv-notebook = {git="https://github.com/igvteam/igv-notebook.git", branch="main"}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Currently igv-notebook is not available from PyPI, so we cannot list it as a dependency. Make it optional, requiring user installation.