### PR TITLE
Add new and improved AIMs

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -6191,7 +6191,7 @@ class Ag3:
 
         return ds
 
-    def plot_aims_heatmap(
+    def plot_aim_heatmap(
         self,
         aims,
         sample_sets=None,
@@ -6275,7 +6275,7 @@ class Ag3:
             column_titles=contigs,
             row_titles=None,
             column_widths=col_widths,
-            x_title="Markers",
+            x_title="Variants",
             y_title="Samples",
             horizontal_spacing=0.01,
             vertical_spacing=0.01,
@@ -6324,7 +6324,7 @@ class Ag3:
                     ),
                     hovertemplate=dedent(
                         """
-                        Marker index: %{x}<br>
+                        Variant index: %{x}<br>
                         Sample: %{y}<br>
                         Genotype: %{z}
                         <extra></extra>

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -6100,8 +6100,8 @@ class Ag3:
 
         return fig
 
-    def aim_sites(self, aims):
-        """Open ancestry informative marker sites.
+    def aim_variants(self, aims):
+        """Open ancestry informative marker variants.
 
         Parameters
         ----------
@@ -6116,9 +6116,10 @@ class Ag3:
         try:
             ds = self._cache_aims[aims]
         except KeyError:
-            path = f"{self._base_path}/reference/aim_defs/{aims}.zarr"
+            path = f"{self._base_path}/reference/aim_defs_20220528/{aims}.zarr"
             store = init_zarr_store(fs=self._fs, path=path)
             ds = xr.open_zarr(store, concat_characters=False)
+            ds = ds.set_coords(["variant_contig", "variant_position"])
             self._cache_aims[aims] = ds
         return ds.copy(deep=False)
 

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -67,7 +67,8 @@ GENOME_ZARR_PATH = (
     "reference/genome/agamp4/Anopheles-gambiae-PEST_CHROMOSOMES_AgamP4.zarr"
 )
 
-DEFAULT_SPECIES_ANALYSIS = "aim_20200422"
+# DEFAULT_SPECIES_ANALYSIS = "aim_20200422"
+DEFAULT_SPECIES_ANALYSIS = "aim_20220528"
 DEFAULT_SITE_FILTERS_ANALYSIS = "dt_20200416"
 DEFAULT_COHORTS_ANALYSIS = "20211101"
 CONTIGS = "2R", "2L", "3R", "3L", "X"
@@ -519,10 +520,27 @@ class Ag3:
             release = self._lookup_release(sample_set=sample_set)
             release_path = _release_to_path(release)
             path_prefix = f"{self._base_path}/{release_path}/metadata"
-            if self._species_analysis == "aim_20200422":
+            if self._species_analysis == "aim_20220528":
+                path = f"{path_prefix}/species_calls_aim_20220528/{sample_set}/samples.species_aim.csv"
+                dtype = {
+                    "aim_species_gambcolu_arabiensis": object,
+                    "aim_species_gambiae_coluzzii": object,
+                    "aim_species": object,
+                }
+            elif self._species_analysis == "aim_20200422":
+                # TODO this is legacy, deprecate at some point
                 path = f"{path_prefix}/species_calls_20200422/{sample_set}/samples.species_aim.csv"
+                dtype = {
+                    "species_gambcolu_arabiensis": object,
+                    "species_gambiae_coluzzii": object,
+                }
             elif self._species_analysis == "pca_20200422":
+                # TODO this is legacy, deprecate at some point
                 path = f"{path_prefix}/species_calls_20200422/{sample_set}/samples.species_pca.csv"
+                dtype = {
+                    "species_gambcolu_arabiensis": object,
+                    "species_gambiae_coluzzii": object,
+                }
             else:
                 raise ValueError(
                     f"Unknown species calling analysis: {self._species_analysis!r}"
@@ -530,12 +548,9 @@ class Ag3:
             with self._fs.open(path) as f:
                 df = pd.read_csv(
                     f,
-                    na_values="",
+                    na_values=["", "NA"],
                     # ensure correct dtype even where all values are missing
-                    dtype={
-                        "species_gambcolu_arabiensis": object,
-                        "species_gambiae_coluzzii": object,
-                    },
+                    dtype=dtype,
                 )
 
             # add a single species call column, for convenience
@@ -558,9 +573,9 @@ class Ag3:
                     # some individuals, e.g., crosses, have a missing species call
                     return np.nan
 
-            df["species"] = df.apply(consolidate_species, axis=1)
-
             if self._species_analysis == "aim_20200422":
+                # TODO this is legacy, deprecate at some point
+                df["species"] = df.apply(consolidate_species, axis=1)
                 # normalise column prefixes
                 df = df.rename(
                     columns={
@@ -572,6 +587,8 @@ class Ag3:
                     }
                 )
             elif self._species_analysis == "pca_20200422":
+                # TODO this is legacy, deprecate at some point
+                df["species"] = df.apply(consolidate_species, axis=1)
                 # normalise column prefixes
                 df = df.rename(
                     # normalise column prefixes

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -6198,6 +6198,7 @@ class Ag3:
         sample_query=None,
         sort=True,
         row_height=4,
+        colors="T10",
     ):
         """Plot a heatmap of ancestry-informative marker (AIM) genotypes.
 
@@ -6217,6 +6218,8 @@ class Ag3:
             alleles for the second species in the comparison.
         row_height : int, optional
             Height per sample in px.
+        colors : str, optional
+            Choose your favourite color palette.
 
         Returns
         -------
@@ -6227,6 +6230,7 @@ class Ag3:
         debug = self._log.debug
 
         import allel
+        import plotly.express as px
         import plotly.graph_objects as go
         from plotly.subplots import make_subplots
 
@@ -6260,11 +6264,50 @@ class Ag3:
             gn = np.take(gn, ix_sorted, axis=1)
             samples = np.take(samples, ix_sorted, axis=0)
 
-        debug("setup colors")
-        if aims == "gambcolu_vs_arab":
-            colors = ["white", "purple", "orange", "green"]
+        debug("set up colors")
+        # https://en.wiktionary.org/wiki/abandon_hope_all_ye_who_enter_here
+        if colors.lower() == "plotly":
+            palette = px.colors.qualitative.Plotly
+            color_gc = palette[3]
+            color_gc_a = palette[9]
+            color_a = palette[2]
+            color_g = palette[0]
+            color_g_c = palette[9]
+            color_c = palette[1]
+            color_m = "white"
+        elif colors.lower() == "set1":
+            palette = px.colors.qualitative.Set1
+            color_gc = palette[3]
+            color_gc_a = palette[4]
+            color_a = palette[2]
+            color_g = palette[1]
+            color_g_c = palette[5]
+            color_c = palette[0]
+            color_m = "white"
+        elif colors.lower() == "g10":
+            palette = px.colors.qualitative.G10
+            color_gc = palette[4]
+            color_gc_a = palette[2]
+            color_a = palette[3]
+            color_g = palette[0]
+            color_g_c = palette[2]
+            color_c = palette[8]
+            color_m = "white"
+        elif colors.lower() == "t10":
+            palette = px.colors.qualitative.T10
+            color_gc = palette[6]
+            color_gc_a = palette[5]
+            color_a = palette[4]
+            color_g = palette[0]
+            color_g_c = palette[5]
+            color_c = palette[2]
+            color_m = "white"
         else:
-            colors = ["white", "blue", "yellow", "red"]
+            raise ValueError("unsupported colors")
+        if aims == "gambcolu_vs_arab":
+            colors = [color_m, color_gc, color_gc_a, color_a]
+        else:
+            colors = [color_m, color_g, color_g_c, color_c]
         species = aims.split("_vs_")
 
         debug("create subplots")

--- a/tests/anopheles_test_data/v3/metadata/species_calls_20200422/test_sample_set/samples.species_aim.csv
+++ b/tests/anopheles_test_data/v3/metadata/species_calls_20200422/test_sample_set/samples.species_aim.csv
@@ -1,4 +1,0 @@
-sample_id,aim_fraction_colu,aim_fraction_arab,species_gambcolu_arabiensis,species_gambiae_coluzzii
-AR0047-C,0.945,0.001,gamb_colu,coluzzii
-AR0049-C,0.933,0.001,gamb_colu,coluzzii
-AR0051-C,0.937,0.002,gamb_colu,coluzzii

--- a/tests/anopheles_test_data/v3/metadata/species_calls_aim_20220528/test_sample_set/samples.species_aim.csv
+++ b/tests/anopheles_test_data/v3/metadata/species_calls_aim_20220528/test_sample_set/samples.species_aim.csv
@@ -1,0 +1,4 @@
+sample_id,aim_species_fraction_arab,aim_species_fraction_colu,aim_species_fraction_colu_no2L,aim_species_gambcolu_arabiensis,aim_species_gambiae_coluzzii,aim_species
+AR0047-C,0.000957670944263551,0.8567335243553008,0.9455445544554455,gambcolu,coluzzii,coluzzii
+AR0049-C,0.0007665772326561902,0.8219669777458722,0.9354838709677419,gambcolu,coluzzii,coluzzii
+AR0051-C,0.0007658433850277618,0.8258992805755395,0.9386401326699834,gambcolu,coluzzii,coluzzii

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -2907,9 +2907,9 @@ def _compare_series_like(actual, expect):
 
 
 @pytest.mark.parametrize("aims", ["gamb_vs_colu", "gambcolu_vs_arab"])
-def test_aim_sites(aims):
+def test_aim_variants(aims):
     ag3 = setup_ag3()
-    ds = ag3.aim_sites(aims)
+    ds = ag3.aim_variants(aims=aims)
 
     # check dataset
     assert isinstance(ds, xr.Dataset)
@@ -2941,12 +2941,12 @@ def test_aim_sites(aims):
     assert x.dims == ("variants", "alleles")
     assert x.dtype == "S1"
 
-    # check atttributes
-    assert ds.attrs == {"contigs": ["2R", "2L", "3R", "3L", "X"]}
+    # check attributes
+    assert ds.attrs["contigs"] == ["2R", "2L", "3R", "3L", "X"]
 
     # check dimension lengths
     assert ds.dims["alleles"] == 2
     if aims == "gamb_vs_colu":
-        assert ds.dims["variants"] == 729
+        assert ds.dims["variants"] == 700
     elif aims == "gambcolu_vs_arab":
-        assert ds.dims["variants"] == 565329
+        assert ds.dims["variants"] == 2612


### PR DESCRIPTION
* Upgrade the default species analysis to use the new (20220528) AIM species metadata.
* Rename `aim_sites()` to `aim_variants()` for naming consistency with `snp_variants()`.
* Upgrade `aim_variants()` to use new AIMs.
* Add `aim_calls()` accessing the precomputed AIMs (supersedes #244).
* Add `plot_aim_heatmap()`.

Resolves #236.