### PR TITLE
adds title to plot_haplotype_clustering function 

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -6138,9 +6138,20 @@ class Ag3(AnophelesDataResource):
             hoverinfo="y",
             line=dict(width=0.5, color="black"),
         )
+
+        if not sample_sets and not sample_query:
+            title = f"genomic window:    {region}<br>number of SNPs:    {ht.shape[0]}"
+        elif not sample_sets:
+            title = f"sample query:    {sample_query}<br>genomic window:    {region}<br>number of SNPs:    {ht.shape[0]}"
+        elif not sample_query:
+            title = f"sample sets:    {sample_sets}<br>genomic window:    {region}<br>number of SNPs:    {ht.shape[0]}"
+        else:
+            title = f"sample sets:    {sample_sets},    sample query:    {sample_query}<br>genomic window:    {region}<br>number of SNPs:    {ht.shape[0]}"
+
         fig.update_layout(
             width=width,
             height=height,
+            title=title,
             autosize=True,
             hovermode="closest",
             plot_bgcolor="white",


### PR DESCRIPTION
Adding a title to `plot_haplotype_clustering()` function with information on selected sample set/sample query, the genomic region and the number of SNPs found in that window. 

I added a line for sample query, similar to H12/H1X functions. Not sure if that is really desirable, let me know and ill change it. Also have added prefix to title like `sample query:` or `number of SNPs:`, happy to remove if preferred. 

Currently looks like this:

![image](https://user-images.githubusercontent.com/34922269/200353594-38d9575d-2bec-4316-a946-044d33718085.png)
