### PR TITLE
Fix haplotype network grey pie segments for countries with a space in the name

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -6346,23 +6346,32 @@ class Ag3(AnophelesDataResource):
 
         debug("setup colors")
         color_values = None
+        color_values_display = None
+        color_discrete_map = None
+        color_discrete_map_display = None
         ht_color_counts = None
-        color_params = None
         if color is not None:
 
+            # sanitise color column - necessary to avoid grey pie chart segments
+            df_haps["partition"] = df_haps[color].str.replace(r"\W", "", regex=True)
+
             # extract all unique values of the color column
-            color_values = df_haps[color].unique()
+            color_values = df_haps["partition"].unique()
+            color_values_mapping = dict(zip(df_haps["partition"], df_haps[color]))
+            color_values_display = [color_values_mapping[c] for c in color_values]
 
             # count color values for each distinct haplotype
             ht_color_counts = [
-                df_haps.iloc[list(s)][color].value_counts().to_dict()
+                df_haps.iloc[list(s)]["partition"].value_counts().to_dict()
                 for s in ht_distinct_sets
             ]
 
             if color == "taxon":
-                # special case, standardise taxon colors
+                # special case, standardise taxon colors and order
                 color_params = self._setup_taxon_colors()
                 color_discrete_map = color_params["color_discrete_map"]
+                color_discrete_map_display = color_discrete_map
+                category_orders = color_params["category_orders"]
 
             elif color_discrete_map is None:
 
@@ -6377,10 +6386,11 @@ class Ag3(AnophelesDataResource):
                 color_discrete_map = {
                     v: c for v, c in zip(color_values, cycle(color_discrete_sequence))
                 }
-
-                color_params = {
-                    "color_discrete_map": color_discrete_map,
-                    "category_orders": category_orders,
+                color_discrete_map_display = {
+                    v: c
+                    for v, c in zip(
+                        color_values_display, cycle(color_discrete_sequence)
+                    )
                 }
 
         debug("construct graph")
@@ -6420,6 +6430,7 @@ class Ag3(AnophelesDataResource):
                 node_stylesheet["style"][
                     f"pie-{i + 1}-background-size"
                 ] = f"mapData({v}, 0, 100, 0, 100)"
+        debug(node_stylesheet)
 
         debug("define edge style")
         edge_stylesheet = {
@@ -6441,8 +6452,9 @@ class Ag3(AnophelesDataResource):
         if color is not None:
             legend_fig = plotly_discrete_legend(
                 color=color,
-                color_values=color_values,
-                **color_params,
+                color_values=color_values_display,
+                color_discrete_map=color_discrete_map_display,
+                category_orders=category_orders,
             )
             legend_component = dcc.Graph(
                 id="legend",
@@ -6488,7 +6500,7 @@ class Ag3(AnophelesDataResource):
 
         debug("create dash app")
         app = JupyterDash(
-            "dash cytoscape network",
+            "dash-cytoscape-network",
             # this stylesheet is used to provide support for a rows and columns
             # layout of the components
             external_stylesheets=["https://codepen.io/chriddyp/pen/bWLwgP.css"],
@@ -6522,17 +6534,18 @@ class Ag3(AnophelesDataResource):
             "define a callback function to display information about the selected node"
         )
 
-        # FIXME: function name should be lowercase
         @app.callback(Output("output", "children"), Input("cytoscape", "tapNodeData"))
-        def displayTapNodeData(data):
+        def display_tap_node_data(data):
             if data is None:
                 return "Click or tap a node for more information."
             else:
                 n = data["count"]
                 text = f"No. haplotypes: {n}"
                 selected_color_data = {
-                    color_v: int(data.get(color_v, 0) * n / 100)
-                    for color_v in color_values
+                    color_v_display: int(data.get(color_v, 0) * n / 100)
+                    for color_v, color_v_display in zip(
+                        color_values, color_values_display
+                    )
                 }
                 selected_color_data = sorted(
                     selected_color_data.items(), key=lambda item: item[1], reverse=True

--- a/notebooks/plot_haplotype_networks.ipynb
+++ b/notebooks/plot_haplotype_networks.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "9de62268",
    "metadata": {},
    "outputs": [],
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "0ebfe96b",
    "metadata": {},
    "outputs": [
@@ -387,7 +387,7 @@
        "https://malariagen.github.io/vector-data/ag3/api.html"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -411,14 +411,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "97bcbded",
+   "execution_count": 3,
+   "id": "1f6bb7f1",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cfc28e2f7373485587583b33d24a5de2",
+       "model_id": "41fc6aa49e3542c5bd89bfaa04ae4f10",
        "version_major": 2,
        "version_minor": 0
       },
@@ -432,7 +432,60 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5bb7dea746b7406381a62595e8980937",
+       "model_id": "164e6ca8218549668f5edb6467b365e9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Load haplotypes:   0%|          | 0/50 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"100%\"\n",
+       "            height=\"650\"\n",
+       "            src=\"http://127.0.0.1:8049/\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "            \n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.IFrame at 0x7febcebb3250>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ag3.plot_haplotype_network(\n",
+    "    region=\"2L:2,358,158-2,431,617\",\n",
+    "    analysis=\"gamb_colu\",\n",
+    "    sample_query=\"taxon == 'coluzzii'\",\n",
+    "    color=\"country\",\n",
+    "    max_dist=2,\n",
+    "    server_port=8049,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "97bcbded",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "347be210f1c044a490398b50079885fd",
        "version_major": 2,
        "version_minor": 0
       },
@@ -458,7 +511,7 @@
        "        "
       ],
       "text/plain": [
-       "<IPython.lib.display.IFrame at 0x7f7b2bf78910>"
+       "<IPython.lib.display.IFrame at 0x7febcd279650>"
       ]
      },
      "metadata": {},
@@ -479,14 +532,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "8200a1cb",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "897caefe06ea4e65b949a3268783d265",
+       "model_id": "7f4d5054344d4341bef567fb50fff4c6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -512,7 +565,7 @@
        "        "
       ],
       "text/plain": [
-       "<IPython.lib.display.IFrame at 0x7f7bb4101f50>"
+       "<IPython.lib.display.IFrame at 0x7febcd2510d0>"
       ]
      },
      "metadata": {},
@@ -533,14 +586,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "id": "b525b324",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "98727464fa47452387c8cba516223dad",
+       "model_id": "0d7f7f3c5c2e4ca2bb45993d5f07604d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -566,7 +619,7 @@
        "        "
       ],
       "text/plain": [
-       "<IPython.lib.display.IFrame at 0x7f7bb5d13390>"
+       "<IPython.lib.display.IFrame at 0x7febcd24dfd0>"
       ]
      },
      "metadata": {},
@@ -610,7 +663,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.14"
+   "version": "3.7.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Haplotype networks coloured by country were breaking if any country name with a space was present. Here we fix that by sanitising the column used for colouring to strip spaces (and other punctuation just to be sure). 