### PR TITLE
Auto versionining and release

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,11 @@
 name: linting
-on: pull_request
-
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 jobs:
   linting:
     strategy:

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -1,6 +1,11 @@
 name: notebooks
-on: pull_request
-
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 jobs:
   notebooks:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: release
+on:
+  push:
+    tags:
+      - "v*.*.*"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and publish to pypi
+        uses: JRubics/poetry-publish@v1.15
+        with:
+          pypi_token: ${{ secrets.PYPI_TOKEN }}
+          plugins: "poetry-dynamic-versioning-plugin"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 name: tests
-on: pull_request
-
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 jobs:
   tests:
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ dash = "*"
 dash-cytoscape = "*"
 jupyter-dash = "*"
 
-
 [tool.poetry.dev-dependencies]
 pytest = "*"
 pytest-xdist = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "malariagen_data"
-version = "7.1.2"
+version = "0.0.0"
 description = "A package for accessing and analysing MalariaGEN data."
 authors = [
     "Alistair Miles <alistair.miles@sanger.ac.uk>",
@@ -61,8 +61,13 @@ black = "*"
 snakeviz = "*"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.isort]
 profile = "black"
+
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+style = "semver"


### PR DESCRIPTION
This PR sets up two things:

* Automatic versioning based on git tags, via the [poetry-dynamic-versioning](https://pypi.org/project/poetry-dynamic-versioning/) plugin
* A github action to publish to PyPI when a new github tag is created, using the [poetry-publish](https://github.com/marketplace/actions/publish-python-poetry-package) action

If this works, then this will mean that the only thing we ever need to do to create a new PyPI release is to create a new github release. 