### PR TITLE
Pin bokeh below 3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,9 @@ scikit-allel = "*"
 xarray = "*"
 numba = "*"
 plotly = "*"
-bokeh = "*"
+# https://github.com/bokeh/bokeh/issues/12614
+# bokeh 3.0 has a problem with stretch sizing modes
+bokeh = "<3.0"
 statsmodels = "*"
 # 0.17.0 appears to be broken on colab
 ipyleaflet = ">0.17.0"


### PR DESCRIPTION
Bokeh 3.0 has a [regression](https://github.com/bokeh/bokeh/issues/12614) which breaks stretch sizing modes. Pin bokeh below 3.0 for the time being.