### PR TITLE
concatenate chromosomal arms in Ag3 and add iHS method 

### DIFF
--- a/malariagen_data/af1.py
+++ b/malariagen_data/af1.py
@@ -38,6 +38,8 @@ FST_GWSS_CACHE_NAME = "af1_fst_gwss_v1"
 H12_CALIBRATION_CACHE_NAME = "af1_h12_calibration_v1"
 H12_GWSS_CACHE_NAME = "af1_h12_gwss_v1"
 H1X_GWSS_CACHE_NAME = "af1_h1x_gwss_v1"
+IHS_GWSS_CACHE_NAME = "af1_ihs_gwss_v1"
+
 
 DEFAULT_SITE_MASK = "funestus"
 
@@ -110,6 +112,9 @@ class Af1(AnophelesDataResource):
     _h12_calibration_cache_name = H12_CALIBRATION_CACHE_NAME
     _h12_gwss_cache_name = H12_GWSS_CACHE_NAME
     _h1x_gwss_cache_name = H1X_GWSS_CACHE_NAME
+    _ihs_gwss_cache_name = IHS_GWSS_CACHE_NAME
+    IHS_GWSS_CACHE_NAME = "ag3_ihs_gwss_v1"
+
     site_mask_ids = ("funestus",)
     _default_site_mask = DEFAULT_SITE_MASK
     _site_annotations_zarr_path = SITE_ANNOTATIONS_ZARR_PATH

--- a/malariagen_data/af1.py
+++ b/malariagen_data/af1.py
@@ -30,6 +30,7 @@ GENOME_REF_ID = "idAnoFuneDA-416_04"
 GENOME_REF_NAME = "Anopheles funestus"
 
 CONTIGS = "2RL", "3RL", "X"
+CHROMOSOMES = "2RL", "3RL", "X"
 
 PCA_RESULTS_CACHE_NAME = "af1_pca_v1"
 SNP_ALLELE_COUNTS_CACHE_NAME = "af1_snp_allele_counts_v2"
@@ -94,6 +95,7 @@ class Af1(AnophelesDataResource):
     """
 
     contigs = CONTIGS
+    chromosomes = CHROMOSOMES
     _major_version_int = MAJOR_VERSION_INT
     _major_version_gcs_str = MAJOR_VERSION_GCS_STR
     _genome_fasta_path = GENOME_FASTA_PATH

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -356,7 +356,7 @@ class Ag3(AnophelesDataResource):
             genome = self.open_genome()
             contigs = (
                 region.contig[0] + region.contig[1],
-                region.contig[0] + region.contig[1],
+                region.contig[0] + region.contig[2],
             )
 
             d = da.concatenate(

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -361,9 +361,7 @@ class Ag3(AnophelesDataResource):
 
             d = da.concatenate(
                 [
-                    da_from_zarr(
-                        genome[contig], inline_array=inline_array, chunks=chunks
-                    )
+                    super().genome_sequence(region=contig, inline_array=inline_array, chunks=chunks)
                     for contig in contigs
                 ]
             )

--- a/malariagen_data/amin1.py
+++ b/malariagen_data/amin1.py
@@ -50,6 +50,10 @@ class Amin1:
             )
         return self._contigs
 
+    @property
+    def chromosomes(self):
+        return self.contigs
+
     def sample_metadata(self):
         """Access sample metadata.
 

--- a/malariagen_data/plasmodium.py
+++ b/malariagen_data/plasmodium.py
@@ -43,6 +43,7 @@ class PlasmodiumDataResource:
         self.extended_calldata_variables = self.CONF["extended_calldata_variables"]
         self.extended_variant_fields = self.CONF["extended_variant_fields"]
         self.contigs = self.CONF["reference_contigs"]
+        self.chromosomes = self.contigs
 
     def _load_config(self, data_config):
         """Load the config for data structure on the cloud into json format."""

--- a/malariagen_data/util.py
+++ b/malariagen_data/util.py
@@ -356,7 +356,7 @@ def _handle_region_coords(resource, region):
         start = int(region_split[1].replace(",", ""))
         end = int(region_split[2].replace(",", ""))
 
-        if contig not in resource.contigs:
+        if contig not in resource.contigs and contig not in resource.chromosomes:
             raise ValueError(f"Contig {contig} does not exist in the dataset.")
         elif (
             start < 0
@@ -415,6 +415,10 @@ def resolve_region(resource, region):
 
     # check if region is a chromosome arm
     if region in resource.contigs:
+        return Region(region, None, None)
+
+    # check if region is a whole chromosome
+    if region in resource.chromosomes:
         return Region(region, None, None)
 
     # check if region is a region string providing coordinates


### PR DESCRIPTION
In this PR I have added functionality to concatenate contigs in `genome_sequence()`, `genome_features()`, `snp_genotypes()`, `snp_calls()` and `haplotypes()`. This functionality has been added solely for Ag3 in `ag3.py`, overwriting these methods and using the `super()` method to call the `AnophelesDataResource` methods. 

A few points:

- How is best to get the maximum value for the right chromosomal arm? - mostly, I have used `genome_sequence('2/3R').shape[0]`. Im assuming here we don't need to worry about any off by one errors, please correct if wrong. 

- To allow 2/3RL input in Ag3, I added a chromosome property (in addition to contig) and added a check in  `resolve_regions` in util.py. However, this means I had to add chromosome properties for Amin, Af1, and plasmodium (in which I just copied values for contigs). I dont know if this is ideal and there may have been an simpler way. 

- The way I've done it, it is not possible to use an input region list mixing contigs and chromosomes such as ['2R', '3RL']. 
- I still need to add tests and add documentation. 

- PS. The docstring for `genome_sequence()` previously stated it can take a list of regions, but I'm pretty sure it can't. I didn't change this yet. 

I have also added a method to perform iHS GWSS scans, with an optional MAF filter and optional custom function to summarise iHS across windows (np.nanmax is default). 

apologies for the lack of separate commits. 