### PR TITLE
ag3.genome_features() - add support for joined arms

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -564,6 +564,26 @@ class Ag3(AnophelesDataResource):
             contig=contig, inline_array=inline_array, chunks=chunks
         )
 
+    def _genome_features_array(self, *, contig, attributes):
+        """Obtain the genome features for a given contig as a pandas DataFrame."""
+
+        if contig in self.virtual_contigs:
+            contig_r, contig_l = _chrom_to_contigs(contig)
+
+            df_r = super()._genome_features_array(
+                contig=contig_r, attributes=attributes
+            )
+            df_l = super()._genome_features_array(
+                contig=contig_l, attributes=attributes
+            )
+            max_r = super().genome_sequence(region=contig_r).shape[0]
+            df_l = df_l.assign(
+                start=lambda x: x.start + max_r, end=lambda x: x.end + max_r
+            )
+            return pd.concat([df_r, df_l], axis=0)
+
+        return super()._genome_features_array(contig=contig, attributes=attributes)
+
     def open_cnv_hmm(self, sample_set):
         """Open CNV HMM zarr.
 

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -546,43 +546,45 @@ class Ag3(AnophelesDataResource):
 
         return self._cache_cross_metadata.copy()
 
-    def _genome_sequence_array(self, *, contig, inline_array, chunks):
+    def _genome_sequence_for_contig(self, *, contig, inline_array, chunks):
         """Obtain the genome sequence for a given contig as an array."""
 
         if contig in self.virtual_contigs:
             # handle virtual contig with joined arms
             contig_r, contig_l = _chrom_to_contigs(contig)
-            d_r = super()._genome_sequence_array(
+            d_r = super()._genome_sequence_for_contig(
                 contig=contig_r, inline_array=inline_array, chunks=chunks
             )
-            d_l = super()._genome_sequence_array(
+            d_l = super()._genome_sequence_for_contig(
                 contig=contig_l, inline_array=inline_array, chunks=chunks
             )
             return da.concatenate([d_r, d_l])
 
-        return super()._genome_sequence_array(
+        return super()._genome_sequence_for_contig(
             contig=contig, inline_array=inline_array, chunks=chunks
         )
 
-    def _genome_features_array(self, *, contig, attributes):
+    def _genome_features_for_contig(self, *, contig, attributes):
         """Obtain the genome features for a given contig as a pandas DataFrame."""
 
         if contig in self.virtual_contigs:
             contig_r, contig_l = _chrom_to_contigs(contig)
 
-            df_r = super()._genome_features_array(
+            df_r = super()._genome_features_for_contig(
                 contig=contig_r, attributes=attributes
             )
-            df_l = super()._genome_features_array(
+            df_l = super()._genome_features_for_contig(
                 contig=contig_l, attributes=attributes
             )
             max_r = super().genome_sequence(region=contig_r).shape[0]
             df_l = df_l.assign(
                 start=lambda x: x.start + max_r, end=lambda x: x.end + max_r
             )
-            return pd.concat([df_r, df_l], axis=0)
+            df = pd.concat([df_r, df_l], axis=0)
+            df = df.assign(contig=contig)
+            return df
 
-        return super()._genome_features_array(contig=contig, attributes=attributes)
+        return super()._genome_features_for_contig(contig=contig, attributes=attributes)
 
     def open_cnv_hmm(self, sample_set):
         """Open CNV HMM zarr.

--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -1764,7 +1764,7 @@ class AnophelesDataResource(ABC):
             self._cache_genome = zarr.open_consolidated(store=store)
         return self._cache_genome
 
-    def _genome_sequence_array(self, *, contig, inline_array, chunks):
+    def _genome_sequence_for_contig(self, *, contig, inline_array, chunks):
         """Obtain the genome sequence for a given contig as an array."""
         assert contig in self.contigs
         genome = self.open_genome()
@@ -1799,7 +1799,7 @@ class AnophelesDataResource(ABC):
         region = self.resolve_region(region)
 
         # obtain complete sequence for the requested contig
-        d = self._genome_sequence_array(
+        d = self._genome_sequence_for_contig(
             contig=region.contig, inline_array=inline_array, chunks=chunks
         )
 
@@ -2920,7 +2920,7 @@ class AnophelesDataResource(ABC):
 
         return str(region)
 
-    def _genome_features_array(self, *, contig, attributes):
+    def _genome_features_for_contig(self, *, contig, attributes):
         """Obtain the genome features for a given contig as a pandas DataFrame."""
         debug = self._log.debug
 
@@ -2979,7 +2979,7 @@ class AnophelesDataResource(ABC):
             debug("apply region query")
             parts = []
             for r in region:
-                df_part = self._genome_features_array(
+                df_part = self._genome_features_for_contig(
                     contig=r.contig, attributes=attributes
                 )
                 if r.end is not None:
@@ -2991,7 +2991,7 @@ class AnophelesDataResource(ABC):
             return df.reset_index(drop=True).copy()
 
         return (
-            self._genome_features_array(contig=None, attributes=attributes)
+            self._genome_features_for_contig(contig=None, attributes=attributes)
             .reset_index(drop=True)
             .copy()
         )

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -291,9 +291,11 @@ def test_genome_features_joined_arms(chrom):
     max_r = ag3.genome_sequence(contig_r).shape[0]
     df_l = df_l.assign(start=lambda x: x.start + max_r, end=lambda x: x.end + max_r)
     df_concat = pd.concat([df_r, df_l], axis=0).reset_index(drop=True)
+    df_concat = df_concat.assign(contig=chrom)
     df = ag3.genome_features(region=chrom)
     assert isinstance(df, pd.DataFrame)
     assert df.shape[0] == df_r.shape[0] + df_l.shape[0]
+    assert all(df["contig"] == chrom)
     assert_frame_equal(df, df_concat)
 
 
@@ -302,11 +304,9 @@ def test_genome_features_joined_arms(chrom):
 )
 def test_genome_features_joined_arms_region(region):
     ag3 = setup_ag3()
-    contigs = (region[0] + region[1], region[0] + region[2])
     df = ag3.genome_features(region=region)
     assert isinstance(df, pd.DataFrame)
-    assert all(np.isin(df.contig.unique(), contigs))
-    assert all(np.isin(contigs, df.contig.unique()))
+    assert df["contig"].unique() == region.split(":")[0]
 
 
 @pytest.mark.parametrize("mask", ["gamb_colu_arab", "gamb_colu", "arab"])

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -281,6 +281,34 @@ def test_genome_sequence_joined_arms_region(region):
     assert seq.shape[0] == 1_000_001
 
 
+@pytest.mark.parametrize("chrom", ["2RL", "3RL"])
+def test_genome_features_joined_arms(chrom):
+    ag3 = setup_ag3()
+    contig_r = chrom[0] + chrom[1]
+    contig_l = chrom[0] + chrom[2]
+    df_r = ag3.genome_features(region=contig_r)
+    df_l = ag3.genome_features(region=contig_l)
+    max_r = ag3.genome_sequence(contig_r).shape[0]
+    df_l = df_l.assign(start=lambda x: x.start + max_r, end=lambda x: x.end + max_r)
+    df_concat = pd.concat([df_r, df_l], axis=0).reset_index(drop=True)
+    df = ag3.genome_features(region=chrom)
+    assert isinstance(df, pd.DataFrame)
+    assert df.shape[0] == df_r.shape[0] + df_l.shape[0]
+    assert_frame_equal(df, df_concat)
+
+
+@pytest.mark.parametrize(
+    "region", ["2RL:61,000,000-62,000,000", "3RL:53,000,000-54,000,000"]
+)
+def test_genome_features_joined_arms_region(region):
+    ag3 = setup_ag3()
+    contigs = (region[0] + region[1], region[0] + region[2])
+    df = ag3.genome_features(region=region)
+    assert isinstance(df, pd.DataFrame)
+    assert all(np.isin(df.contig.unique(), contigs))
+    assert all(np.isin(contigs, df.contig.unique()))
+
+
 @pytest.mark.parametrize("mask", ["gamb_colu_arab", "gamb_colu", "arab"])
 @pytest.mark.parametrize("region", ["3L", ["2R:48,714,463-48,715,355", "AGAP007280"]])
 def test_site_filters(mask, region):


### PR DESCRIPTION
In this PR I have added support for joined chromosomal arms in Ag3 for the `genome_features()` method, following the approach outlined in PR #346. This contributes towards addressing #332. 

- For the private method `_genome_features_array()`, I chose to follow the `_genome_sequence_array()` naming and keep the suffix '_array' even though technically the returned object is a pandas DataFrame. If preferred, we could change this to `_genome_features_frame()` or `_genome_features_df()`. 


