### PR TITLE
plot_haplotype_clustering() fix - append extra metadata to hover data if specified

### DIFF
--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -7824,6 +7824,11 @@ class AnophelesDataResource(ABC):
             "month",
         ]
 
+        if color and color not in hover_data:
+            hover_data.append(color)
+        if symbol and symbol not in hover_data:
+            hover_data.append(symbol)
+
         plot_kwargs = dict(
             template="simple_white",
             hover_name="sample_id",

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -375,7 +375,7 @@ def test_snp_sites_for_joined_arms(chrom):
     assert isinstance(sites_actual, da.Array)
     assert sites_actual.ndim == 1
     assert sites_actual.dtype == "int32"
-    assert np.all(sites_expected == sites_actual)
+    assert da.all(sites_expected == sites_actual)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR fixes a bug where if you specified extra metadata with `add_extra_metadata()` and then tried to use those columns for colors or symbols during `plot_haplotype_clustering()` the extra metadata columns could not be found. 

This is because they needed to be added to a list of hover data columns which is used to subset the metadata. 