### PR TITLE
ag3.haplotypes() - add support for joined arms

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -700,6 +700,43 @@ class Ag3(AnophelesDataResource):
             chunks=chunks,
         )
 
+    def haplotypes_for_contig(
+        self, *, contig, sample_set, analysis, inline_array, chunks
+    ):
+        """Access haplotypes for a single whole chromosome and a single sample sets."""
+
+        if contig in self.virtual_contigs:
+            contig_r, contig_l = _chrom_to_contigs(contig)
+
+            ds_r = super().haplotypes_for_contig(
+                contig=contig_r,
+                sample_set=sample_set,
+                analysis=analysis,
+                inline_array=inline_array,
+                chunks=chunks,
+            )
+            ds_l = super().haplotypes_for_contig(
+                contig=contig_l,
+                sample_set=sample_set,
+                analysis=analysis,
+                inline_array=inline_array,
+                chunks=chunks,
+            )
+
+            max_r = super().genome_sequence(region=contig_r).shape[0]
+            ds_l["variant_position"] = ds_l["variant_position"] + max_r
+            ds = da.concatenate([ds_r, ds_l])
+
+            return ds
+
+        return super().haplotypes_for_contig(
+            contig=contig,
+            sample_set=sample_set,
+            analysis=analysis,
+            inline_array=inline_array,
+            chunks=chunks,
+        )
+
     def open_cnv_hmm(self, sample_set):
         """Open CNV HMM zarr.
 

--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -6661,7 +6661,7 @@ class AnophelesDataResource(ABC):
             self._cache_haplotype_sites[analysis] = root
         return root
 
-    def _haplotypes_dataset(
+    def _haplotypes_for_contig(
         self, *, contig, sample_set, analysis, inline_array, chunks
     ):
         debug = self._log.debug
@@ -6787,7 +6787,7 @@ class AnophelesDataResource(ABC):
             ly = []
 
             for s in sample_sets:
-                y = self._haplotypes_dataset(
+                y = self._haplotypes_for_contig(
                     contig=r.contig,
                     sample_set=s,
                     analysis=analysis,

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -761,6 +761,37 @@ def test_snp_variants_for_joined_arms_region(region):
     assert sites.shape[0] == ds_vars["variant_position"].shape[0]
 
 
+@pytest.mark.parametrize("chrom", ["2RL", "3RL"])
+def test_haplotypes_for_joined_arms(chrom):
+    ag3 = setup_ag3()
+    contig_r = chrom[0] + chrom[1]
+    contig_l = chrom[0] + chrom[2]
+    ds_r = ag3.haplotypes(region=contig_r)
+    ds_l = ag3.haplotypes(region=contig_l)
+    ds_expected = xr.concat([ds_r, ds_l], dim="variants")
+
+    ds_actual = ag3.haplotypes(region=chrom)
+
+    assert isinstance(ds_actual, xr.Dataset)
+    assert len(ds_actual.dims) == 4
+    assert ds_actual["call_genotype"].dtype == "int8"
+    assert ds_actual["variant_position"].dtype == "int32"
+    assert ds_actual["call_genotype"].shape == ds_expected["call_genotype"].shape
+
+
+@pytest.mark.parametrize(
+    "region", ["2RL:61,000,000-62,000,000", "3RL:53,000,000-54,000,000"]
+)
+def test_haplotypes_for_joined_arms_region(region):
+    ag3 = setup_ag3()
+    ds_snps = ag3.haplotypes(region=region)
+
+    assert isinstance(ds_snps, xr.Dataset)
+    assert len(ds_snps.dims) == 4
+    assert ds_snps["call_genotype"].dtype == "int8"
+    assert ds_snps["variant_position"].dtype == "int32"
+
+
 def test_snp_effects():
     ag3 = setup_ag3()
     gste2 = "AGAP009194-RA"

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -375,7 +375,7 @@ def test_snp_sites_for_joined_arms(chrom):
     assert isinstance(sites_actual, da.Array)
     assert sites_actual.ndim == 1
     assert sites_actual.dtype == "int32"
-    assert np.all(sites_expected == sites_actual)
+    assert da.all(sites_expected == sites_actual).compute(scheduler="single-threaded")
 
 
 @pytest.mark.parametrize(
@@ -784,12 +784,12 @@ def test_haplotypes_for_joined_arms(chrom):
 )
 def test_haplotypes_for_joined_arms_region(region):
     ag3 = setup_ag3()
-    ds_snps = ag3.haplotypes(region=region)
+    ds_haps = ag3.haplotypes(region=region)
 
-    assert isinstance(ds_snps, xr.Dataset)
-    assert len(ds_snps.dims) == 4
-    assert ds_snps["call_genotype"].dtype == "int8"
-    assert ds_snps["variant_position"].dtype == "int32"
+    assert isinstance(ds_haps, xr.Dataset)
+    assert len(ds_haps.dims) == 4
+    assert ds_haps["call_genotype"].dtype == "int8"
+    assert ds_haps["variant_position"].dtype == "int32"
 
 
 def test_snp_effects():


### PR DESCRIPTION
In this PR I have added support for joined arms with the `haplotypes()` function, following approaches in #352, #346, #347. Should be the final step in addressing #332. 

As with `snp_calls()` in PR #352 , I have changed `_haplotypes_dataset()` to `_haplotypes_for_contig()`, and implemented an equivalent method in `ag3`. 

Because some sample sets dont have haplotypes, when converting genome coordinates for the left arm of the xr.Dataset, I had to add some logic to say only do this if the left arm ds is not none. 