### PR TITLE
Implement G123 gwss method

### DIFF
--- a/malariagen_data/af1.py
+++ b/malariagen_data/af1.py
@@ -37,6 +37,7 @@ FST_GWSS_CACHE_NAME = "af1_fst_gwss_v1"
 H12_CALIBRATION_CACHE_NAME = "af1_h12_calibration_v1"
 H12_GWSS_CACHE_NAME = "af1_h12_gwss_v1"
 G123_GWSS_CACHE_NAME = "af1_g123_gwss_v1"
+G123_CALIBRATION_CACHE_NAME = "af1_g123_calibration_v1"
 H1X_GWSS_CACHE_NAME = "af1_h1x_gwss_v1"
 IHS_GWSS_CACHE_NAME = "af1_ihs_gwss_v1"
 
@@ -110,6 +111,7 @@ class Af1(AnophelesDataResource):
     _h12_calibration_cache_name = H12_CALIBRATION_CACHE_NAME
     _h12_gwss_cache_name = H12_GWSS_CACHE_NAME
     _g123_gwss_cache_name = G123_GWSS_CACHE_NAME
+    _g123_calibration_cache_name = G123_CALIBRATION_CACHE_NAME
     _h1x_gwss_cache_name = H1X_GWSS_CACHE_NAME
     _ihs_gwss_cache_name = IHS_GWSS_CACHE_NAME
     site_mask_ids = ("funestus",)

--- a/malariagen_data/af1.py
+++ b/malariagen_data/af1.py
@@ -36,6 +36,7 @@ SNP_ALLELE_COUNTS_CACHE_NAME = "af1_snp_allele_counts_v2"
 FST_GWSS_CACHE_NAME = "af1_fst_gwss_v1"
 H12_CALIBRATION_CACHE_NAME = "af1_h12_calibration_v1"
 H12_GWSS_CACHE_NAME = "af1_h12_gwss_v1"
+G123_GWSS_CACHE_NAME = "af1_g123_gwss_v1"
 H1X_GWSS_CACHE_NAME = "af1_h1x_gwss_v1"
 IHS_GWSS_CACHE_NAME = "af1_ihs_gwss_v1"
 
@@ -108,6 +109,7 @@ class Af1(AnophelesDataResource):
     _fst_gwss_results_cache_name = FST_GWSS_CACHE_NAME
     _h12_calibration_cache_name = H12_CALIBRATION_CACHE_NAME
     _h12_gwss_cache_name = H12_GWSS_CACHE_NAME
+    _g123_gwss_cache_name = G123_GWSS_CACHE_NAME
     _h1x_gwss_cache_name = H1X_GWSS_CACHE_NAME
     _ihs_gwss_cache_name = IHS_GWSS_CACHE_NAME
     site_mask_ids = ("funestus",)

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -735,6 +735,9 @@ class Ag3(AnophelesDataResource):
         return super()._haplotype_sites_for_contig(
             contig=contig,
             analysis=analysis,
+            field=field,
+            inline_array=inline_array,
+            chunks=chunks,
         )
 
     def _haplotypes_for_contig(

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -67,6 +67,7 @@ SNP_ALLELE_COUNTS_CACHE_NAME = "ag3_snp_allele_counts_v2"
 FST_GWSS_CACHE_NAME = "ag3_fst_gwss_v1"
 H12_CALIBRATION_CACHE_NAME = "ag3_h12_calibration_v1"
 H12_GWSS_CACHE_NAME = "ag3_h12_gwss_v1"
+G123_GWSS_CACHE_NAME = "ag3_g123_gwss_v1"
 H1X_GWSS_CACHE_NAME = "ag3_h1x_gwss_v1"
 IHS_GWSS_CACHE_NAME = "ag3_ihs_gwss_v1"
 
@@ -144,6 +145,7 @@ class Ag3(AnophelesDataResource):
     _fst_gwss_results_cache_name = FST_GWSS_CACHE_NAME
     _h12_calibration_cache_name = H12_CALIBRATION_CACHE_NAME
     _h12_gwss_cache_name = H12_GWSS_CACHE_NAME
+    _g123_gwss_cache_name = G123_GWSS_CACHE_NAME
     _h1x_gwss_cache_name = H1X_GWSS_CACHE_NAME
     _ihs_gwss_cache_name = IHS_GWSS_CACHE_NAME
     site_mask_ids = ("gamb_colu_arab", "gamb_colu", "arab")

--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -8508,8 +8508,8 @@ class AnophelesDataResource(ABC):
                 field="POS",
                 inline_array=True,
                 chunks="native",
-            )
-            hap_site_mask = np.in1d(pos, haplotype_pos.values)
+            ).compute()
+            hap_site_mask = np.in1d(pos, haplotype_pos)
             pos = pos[hap_site_mask]
             gt = gt.compress(hap_site_mask, axis=0)
         elif sites == "segregating":
@@ -8896,8 +8896,8 @@ class AnophelesDataResource(ABC):
                 field="POS",
                 inline_array=True,
                 chunks="native",
-            )
-            hap_site_mask = np.in1d(pos, haplotype_pos.values)
+            ).compute()
+            hap_site_mask = np.in1d(pos, haplotype_pos)
             gt = gt.compress(hap_site_mask, axis=0)
         elif sites == "segregating":
             debug("subsetting to segregating sites")

--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -8461,7 +8461,7 @@ class AnophelesDataResource(ABC):
 
         if sites == DEFAULT:
             sites = self._default_phasing_analysis
-            valid_sites = self.phasing_analysis_ids + ("all", "segregating")
+        valid_sites = self.phasing_analysis_ids + ("all", "segregating")
         if sites not in valid_sites:
             raise ValueError(
                 f"Invalid value for `sites` parameter, must be one of {valid_sites}."

--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -2135,7 +2135,8 @@ class AnophelesDataResource(ABC):
             chunks. Also, can be a target size, e.g., '200 MiB'.
         cohort_size : int, optional
             If provided, randomly down-sample to the given cohort size. A ValueError
-            will be raised if the cohort size is smaller than the given value.
+            will be raised if the cohort size is smaller than the given value. Overrides
+            min_cohort_size and max_cohort_size.
         max_cohort_size : int, optional
             If provided, randomly down-sample to the given cohort size if the
             cohort size is larger than the given value.

--- a/notebooks/plot_g123_gwss.ipynb
+++ b/notebooks/plot_g123_gwss.ipynb
@@ -35,6 +35,26 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "db33f6d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "contig = '3L'\n",
+    "sample_set = 'AG1000G-BF-A'\n",
+    "sample_query = 'taxon == \"gambiae\"'\n",
+    "site_mask = 'gamb_colu'\n",
+    "\n",
+    "ag3.plot_g123_calibration(\n",
+    "    contig=contig, \n",
+    "    sample_sets=sample_set,\n",
+    "    sample_query=sample_query,\n",
+    "    site_mask=site_mask,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "effd3060",
    "metadata": {},
    "outputs": [],

--- a/notebooks/plot_g123_gwss.ipynb
+++ b/notebooks/plot_g123_gwss.ipynb
@@ -1,0 +1,164 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a31720f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import malariagen_data\n",
+    "\n",
+    "ag3 = malariagen_data.Ag3(\n",
+    "    \"simplecache::gs://vo_agam_release\",\n",
+    "    simplecache=dict(cache_storage=\"../gcs_cache\"),\n",
+    ")\n",
+    "ag3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ece45863",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import malariagen_data\n",
+    "\n",
+    "af1 = malariagen_data.Af1(\n",
+    "    \"simplecache::gs://vo_afun_release\",\n",
+    "    simplecache=dict(cache_storage=\"../gcs_cache\"),\n",
+    ")\n",
+    "af1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "effd3060",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_g123_gwss_track(\n",
+    "    contig='2L', \n",
+    "    window_size=1_000,\n",
+    "    site_mask='gamb_colu',\n",
+    "    sample_query=\"cohort_admin2_year == 'ML-2_Kati_colu_2014'\",\n",
+    "    max_cohort_size=10\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e747d9a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_g123_gwss_track(\n",
+    "    contig='2L', \n",
+    "    window_size=1000,\n",
+    "    site_mask='gamb_colu',\n",
+    "    sample_query=\"cohort_admin2_year == 'ML-2_Kati_colu_2014'\",\n",
+    "    max_cohort_size=30,\n",
+    "    width=700,\n",
+    "    sizing_mode=\"fixed\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b63d02fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_g123_gwss(\n",
+    "    contig='2L', \n",
+    "    window_size=1000,\n",
+    "    sample_query=\"cohort_admin2_year == 'ML-2_Kati_colu_2014'\",\n",
+    "    site_mask='gamb_colu',\n",
+    "    min_cohort_size=10,\n",
+    "    max_cohort_size=20\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f77bbae1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_g123_gwss(\n",
+    "    contig='2L', \n",
+    "    window_size=1_000,\n",
+    "    sample_query=\"cohort_admin2_year == 'ML-2_Kati_colu_2014'\",\n",
+    "    site_mask='gamb_colu',\n",
+    "    max_cohort_size=None\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd3c2a2d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "af1.sample_metadata()[\"cohort_admin1_year\"].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b87b2f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "af1.plot_g123_gwss(\n",
+    "    contig='X', \n",
+    "    window_size=2_000,\n",
+    "    sample_query=\"cohort_admin1_year == 'KE-03_fune_2016'\",\n",
+    "    max_cohort_size=20,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e3fc1c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "af1.plot_g123_gwss(\n",
+    "    contig='X', \n",
+    "    window_size=2000,\n",
+    "    sample_query=\"cohort_admin1_year == 'KE-03_fune_2016'\",\n",
+    "    max_cohort_size=None,\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/plot_g123_gwss.ipynb
+++ b/notebooks/plot_g123_gwss.ipynb
@@ -46,6 +46,7 @@
     "\n",
     "ag3.plot_g123_calibration(\n",
     "    contig=contig, \n",
+    "    sites=site_mask,\n",
     "    sample_sets=sample_set,\n",
     "    sample_query=sample_query,\n",
     "    site_mask=site_mask,\n",

--- a/notebooks/plot_g123_gwss.ipynb
+++ b/notebooks/plot_g123_gwss.ipynb
@@ -64,6 +64,7 @@
     "    contig='2L', \n",
     "    window_size=1_000,\n",
     "    site_mask='gamb_colu',\n",
+    "    sites='gamb_colu',\n",
     "    sample_query=\"cohort_admin2_year == 'ML-2_Kati_colu_2014'\",\n",
     "    max_cohort_size=10\n",
     ")"
@@ -80,6 +81,7 @@
     "    contig='2L', \n",
     "    window_size=1000,\n",
     "    site_mask='gamb_colu',\n",
+    "    sites='segregating',\n",
     "    sample_query=\"cohort_admin2_year == 'ML-2_Kati_colu_2014'\",\n",
     "    max_cohort_size=30,\n",
     "    width=700,\n",
@@ -97,6 +99,7 @@
     "ag3.plot_g123_gwss(\n",
     "    contig='2L', \n",
     "    window_size=1000,\n",
+    "    sites='all',\n",
     "    sample_query=\"cohort_admin2_year == 'ML-2_Kati_colu_2014'\",\n",
     "    site_mask='gamb_colu',\n",
     "    min_cohort_size=10,\n",
@@ -116,6 +119,7 @@
     "    window_size=1_000,\n",
     "    sample_query=\"cohort_admin2_year == 'ML-2_Kati_colu_2014'\",\n",
     "    site_mask='gamb_colu',\n",
+    "    sites='gamb_colu',\n",
     "    max_cohort_size=None\n",
     ")"
    ]
@@ -140,6 +144,8 @@
     "af1.plot_g123_gwss(\n",
     "    contig='X', \n",
     "    window_size=2_000,\n",
+    "    sites='segregating',\n",
+    "    site_mask='funestus',\n",
     "    sample_query=\"cohort_admin1_year == 'KE-03_fune_2016'\",\n",
     "    max_cohort_size=20,\n",
     ")"
@@ -155,6 +161,8 @@
     "af1.plot_g123_gwss(\n",
     "    contig='X', \n",
     "    window_size=2000,\n",
+    "    site_mask='funestus',\n",
+    "    sites='funestus',\n",
     "    sample_query=\"cohort_admin1_year == 'KE-03_fune_2016'\",\n",
     "    max_cohort_size=None,\n",
     ")"

--- a/tests/test_af1.py
+++ b/tests/test_af1.py
@@ -1404,6 +1404,7 @@ def test_g123_gwss():
     x, g123 = af1.g123_gwss(
         contig=contig,
         site_mask=site_mask,
+        sites=site_mask,
         sample_query=sample_query,
         sample_sets=sample_sets,
         window_size=window_size,
@@ -1420,5 +1421,5 @@ def test_g123_gwss():
     assert len(x) == len(g123)
 
     # check some values
-    assert_allclose(x[0], 141187.406)
+    assert_allclose(x[0], 185756.747)
     assert_allclose(g123[11353], 0.022400000000000007)

--- a/tests/test_af1.py
+++ b/tests/test_af1.py
@@ -1391,3 +1391,34 @@ def test_fst_gwss():
     assert_allclose(fst[0], -0.102647, rtol=1e-5), fst[0]
     assert np.all(fst <= 1)
     assert np.all(np.logical_and(fst >= -0.4, fst <= 1))
+
+
+def test_g123_gwss():
+    af1 = setup_af1()
+    sample_query = "country == 'Ghana'"
+    contig = "3RL"
+    site_mask = "funestus"
+    sample_sets = "1.0"
+    window_size = 1000
+
+    x, g123 = af1.g123_gwss(
+        contig=contig,
+        site_mask=site_mask,
+        sample_query=sample_query,
+        sample_sets=sample_sets,
+        window_size=window_size,
+        min_cohort_size=20,
+        max_cohort_size=50,
+    )
+
+    # check dataset
+    assert isinstance(x, np.ndarray)
+    assert isinstance(g123, np.ndarray)
+
+    # check dimensions
+    assert len(x) == 15845
+    assert len(x) == len(g123)
+
+    # check some values
+    assert_allclose(x[0], 141187.406)
+    assert_allclose(g123[11353], 0.022400000000000007)

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -3114,3 +3114,34 @@ def test_ihs_gwss():
     # check some values
     assert_allclose(x[0], 510232.847)
     assert_allclose(ihs[:, 2][100], 2.3467595962486327)
+
+
+def test_g123_gwss():
+    ag3 = setup_ag3()
+    sample_query = "country == 'Ghana'"
+    contig = "3L"
+    site_mask = "gamb_colu"
+    sample_sets = "3.0"
+    window_size = 1000
+
+    x, g123 = ag3.g123_gwss(
+        contig=contig,
+        site_mask=site_mask,
+        sample_query=sample_query,
+        sample_sets=sample_sets,
+        window_size=window_size,
+        min_cohort_size=20,
+        max_cohort_size=50,
+    )
+
+    # check dataset
+    assert isinstance(x, np.ndarray)
+    assert isinstance(g123, np.ndarray)
+
+    # check dimensions
+    assert len(x) == 28707
+    assert len(x) == len(g123)
+
+    # check some values
+    assert_allclose(x[0], 15815.929)
+    assert_allclose(g123[11353], 0.024800000000000006)

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -3126,6 +3126,7 @@ def test_g123_gwss():
 
     x, g123 = ag3.g123_gwss(
         contig=contig,
+        sites=site_mask,
         site_mask=site_mask,
         sample_query=sample_query,
         sample_sets=sample_sets,

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -3140,9 +3140,9 @@ def test_g123_gwss():
     assert isinstance(g123, np.ndarray)
 
     # check dimensions
-    assert len(x) == 28707
+    assert len(x) == 11354
     assert len(x) == len(g123)
 
     # check some values
-    assert_allclose(x[0], 15815.929)
-    assert_allclose(g123[11353], 0.024800000000000006)
+    assert_allclose(x[0], 27701.195)
+    assert_allclose(g123[11353], 0.18799999999999997)

--- a/tests/test_anopheles.py
+++ b/tests/test_anopheles.py
@@ -919,3 +919,41 @@ def test_h12_calibration(
 
     # check keys
     assert list(calibration_runs.keys()) == [str(win) for win in window_sizes]
+
+
+@pytest.mark.parametrize(
+    "subclass, sample_query, contig, site_mask, sample_sets",
+    [
+        (Ag3, "country == 'Ghana'", "3L", "gamb_colu", "3.0"),
+        (Af1, "country == 'Ghana'", "3RL", "funestus", "1.0"),
+    ],
+)
+@pytest.mark.parametrize(
+    "window_sizes",
+    [[100, 200, 500], [10000, 20000]],
+)
+def test_g123_calibration(
+    subclass, sample_query, contig, site_mask, sample_sets, window_sizes
+):
+    url = f"simplecache::{subclass._gcs_url}"
+    anoph = setup_subclass(subclass, url)
+
+    calibration_runs = anoph.g123_calibration(
+        contig=contig,
+        sites=site_mask,
+        site_mask=site_mask,
+        sample_query=sample_query,
+        sample_sets=sample_sets,
+        window_sizes=window_sizes,
+        cohort_size=20,
+    )
+
+    # check dataset
+    assert isinstance(calibration_runs, dict)
+    assert isinstance(calibration_runs[str(window_sizes[0])], np.ndarray)
+
+    # check dimensions
+    assert len(calibration_runs) == len(window_sizes)
+
+    # check keys
+    assert list(calibration_runs.keys()) == [str(win) for win in window_sizes]

--- a/tests/test_anopheles.py
+++ b/tests/test_anopheles.py
@@ -945,7 +945,8 @@ def test_g123_calibration(
         sample_query=sample_query,
         sample_sets=sample_sets,
         window_sizes=window_sizes,
-        cohort_size=20,
+        min_cohort_size=20,
+        max_cohort_size=50,
     )
 
     # check dataset


### PR DESCRIPTION
This PR adds support for the G123 genome-wide selection scan statistic for unphased diplotype data.  I have added a test for each `ag3` and `af1`, and a notebook.

To support G123 calculation, I have made a function `_diplotype_frequencies()` analogous to `_haplotype_frequencies()`. As with the `ihs` functions, I've added support for both a `min` and `max_cohort_size`. 

Main question for @alimanfoo, should I implement a segregating site filter? I think its probably needed, because at the minute we are basically windowing by bases rather than SNPs. 

Resolves #305.