### PR TITLE
Anopheles refactor part 1 - AnophelesBase

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -10,32 +10,28 @@ jobs:
     notebooks:
         strategy:
             fail-fast: true
-            matrix:
-                python-version: ['3.10']
-                poetry-version: ['1.4.1']
-                os: [ubuntu-latest]
-        runs-on: ${{ matrix.os }}
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout source
               uses: actions/checkout@v3
+
+            - name: Setup python
+              uses: actions/setup-python@v4
+              with:
+                  python-version: '3.10'
+                  cache: 'poetry'
+
+            - name: Install poetry
+              run: pipx install poetry==1.4.1
+
+            - name: Install dependencies
+              run: poetry install
 
             - name: Restore GCS cache
               uses: actions/cache/restore@v3
               with:
                   path: gcs_cache
                   key: gcs_cache_notebooks
-
-            - name: Install poetry
-              run: pipx install poetry==${{ matrix.poetry-version }}
-
-            - name: Setup python
-              uses: actions/setup-python@v4
-              with:
-                  python-version: ${{ matrix.python-version }}
-                  cache: 'poetry'
-
-            - name: Install dependencies
-              run: poetry install
 
             - name: Run notebooks
               run: poetry run jupyter nbconvert --execute notebooks/* --inplace

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -15,14 +15,14 @@ jobs:
             - name: Checkout source
               uses: actions/checkout@v3
 
+            - name: Install poetry
+              run: pipx install poetry==1.4.1
+
             - name: Setup python
               uses: actions/setup-python@v4
               with:
                   python-version: '3.10'
                   cache: 'poetry'
-
-            - name: Install poetry
-              run: pipx install poetry==1.4.1
 
             - name: Install dependencies
               run: poetry install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,12 +19,6 @@ jobs:
             - name: Checkout source
               uses: actions/checkout@v3
 
-            - name: Restore GCS cache
-              uses: actions/cache/restore@v3
-              with:
-                  path: gcs_cache
-                  key: gcs_cache_tests
-
             - name: Install poetry
               run: pipx install poetry==${{ matrix.poetry-version }}
 
@@ -37,8 +31,18 @@ jobs:
             - name: Install dependencies
               run: poetry install
 
-            - name: Run tests
-              run: poetry run pytest -v
+            # Run a subset of tests first which run quickly to fail fast.
+            - name: Run fast unit tests
+              run: poetry run pytest -v tests/anoph
+
+            - name: Restore GCS cache
+              uses: actions/cache/restore@v3
+              with:
+                  path: gcs_cache
+                  key: gcs_cache_tests
+
+            - name: Run full test suite
+              run: poetry run pytest -v tests
 
             - name: Save GCS cache
               uses: actions/cache/save@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,21 +12,19 @@ jobs:
             fail-fast: true
             matrix:
                 python-version: ['3.8', '3.9', '3.10']
-                poetry-version: ['1.4.1']
-                os: [ubuntu-latest]
-        runs-on: ${{ matrix.os }}
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout source
               uses: actions/checkout@v3
-
-            - name: Install poetry
-              run: pipx install poetry==${{ matrix.poetry-version }}
 
             - name: Setup python
               uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: 'poetry'
+
+            - name: Install poetry
+              run: pipx install poetry==1.4.1
 
             - name: Install dependencies
               run: poetry install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,14 +17,14 @@ jobs:
             - name: Checkout source
               uses: actions/checkout@v3
 
+            - name: Install poetry
+              run: pipx install poetry==1.4.1
+
             - name: Setup python
               uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: 'poetry'
-
-            - name: Install poetry
-              run: pipx install poetry==1.4.1
 
             - name: Install dependencies
               run: poetry install

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 .ipynb_checkpoints/
 gcs_cache
 results_cache
+tests/anoph/fixture
 
 # emacs
 *~

--- a/README.md
+++ b/README.md
@@ -45,31 +45,31 @@ Fork and clone this repo:
 git clone git@github.com:[username]/malariagen-data-python.git
 ```
 
-Install Python 3.10, e.g.:
+Install Python 3.8 (current recommended version for local development), e.g.:
 
 ```bash
 sudo add-apt-repository ppa:deadsnakes/ppa
-sudo apt install python3.10 python3.10-venv
+sudo apt install python3.8 python3.8-venv
 ```
 
 Install pipx, e.g.:
 
 ```bash
-python3.10 -m pip install --user pipx
-python3.10 -m pipx ensurepath
+python3.8 -m pip install --user pipx
+python3.8 -m pipx ensurepath
 ```
 
 Install [poetry](https://python-poetry.org/docs/#installation), e.g.:
 
 ```bash
-pipx install poetry==1.4.1 --python=/usr/bin/python3.10
+pipx install poetry==1.4.1 --python=/usr/bin/python3.8
 ```
 
 Create development environment:
 
 ```bash
 cd malariagen-data-python
-poetry use 3.10
+poetry use 3.8
 poetry install
 ```
 
@@ -82,7 +82,7 @@ poetry shell
 Install pre-commit and pre-commit hooks:
 
 ```bash
-pipx install pre-commit --python=/usr/bin/python3.10
+pipx install pre-commit --python=/usr/bin/python3.8
 pre-commit install
 ```
 

--- a/malariagen_data/af1.py
+++ b/malariagen_data/af1.py
@@ -97,8 +97,6 @@ class Af1(AnophelesDataResource):
     """
 
     contigs = CONTIGS
-    _major_version_int = MAJOR_VERSION_INT
-    _major_version_gcs_str = MAJOR_VERSION_GCS_STR
     _genome_fasta_path = GENOME_FASTA_PATH
     _genome_fai_path = GENOME_FAI_PATH
     _genome_zarr_path = GENOME_ZARR_PATH
@@ -134,7 +132,7 @@ class Af1(AnophelesDataResource):
         cohorts_analysis=None,
         site_filters_analysis=None,
         pre=False,
-        **kwargs,  # used by simplecache, init_filesystem(url, **kwargs)
+        **storage_kwargs,  # used by fsspec via init_filesystem(url, **kwargs)
     ):
         super().__init__(
             url=url,
@@ -148,7 +146,10 @@ class Af1(AnophelesDataResource):
             show_progress=show_progress,
             check_location=check_location,
             pre=pre,
-            **kwargs,  # used by simplecache, init_filesystem(url, **kwargs)
+            gcs_url=GCS_URL,
+            major_version_number=MAJOR_VERSION_INT,
+            major_version_path=MAJOR_VERSION_GCS_STR,
+            **storage_kwargs,  # used by fsspec via init_filesystem(url, **kwargs)
         )
 
     @staticmethod
@@ -176,7 +177,7 @@ class Af1(AnophelesDataResource):
             f"Cohorts analysis        : {self._cohorts_analysis}\n"
             f"Site filters analysis   : {self._site_filters_analysis}\n"
             f"Software version        : malariagen_data {malariagen_data.__version__}\n"
-            f"Client location         : {self._client_location}\n"
+            f"Client location         : {self.client_location}\n"
             f"---\n"
             f"Please note that data are subject to terms of use,\n"
             f"for more information see https://www.malariagen.net/data\n"
@@ -240,7 +241,7 @@ class Af1(AnophelesDataResource):
                         <th style="text-align: left">
                             Client location
                         </th>
-                        <td>{self._client_location}</td>
+                        <td>{self.client_location}</td>
                     </tr>
                 </tbody>
             </table>

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -31,7 +31,7 @@ from .util import (
 )
 
 # silence dask performance warnings
-dask.config.set(**{"array.slicing.split_large_chunks": False})
+dask.config.set(**{"array.slicing.split_large_chunks": False})  # type: ignore
 
 MAJOR_VERSION_INT = 3
 MAJOR_VERSION_GCS_STR = "v3"
@@ -127,8 +127,6 @@ class Ag3(AnophelesDataResource):
 
     contigs = CONTIGS
     virtual_contigs = "2RL", "3RL"
-    _major_version_int = MAJOR_VERSION_INT
-    _major_version_gcs_str = MAJOR_VERSION_GCS_STR
     _genome_fasta_path = GENOME_FASTA_PATH
     _genome_fai_path = GENOME_FAI_PATH
     _genome_zarr_path = GENOME_ZARR_PATH
@@ -163,7 +161,7 @@ class Ag3(AnophelesDataResource):
         species_analysis=None,
         site_filters_analysis=None,
         pre=False,
-        **kwargs,  # used by simplecache, init_filesystem(url, **kwargs)
+        **storage_kwargs,  # used by simplecache, init_filesystem(url, **kwargs)
     ):
         super().__init__(
             url=url,
@@ -177,7 +175,10 @@ class Ag3(AnophelesDataResource):
             show_progress=show_progress,
             check_location=check_location,
             pre=pre,
-            **kwargs,  # used by simplecache, init_filesystem(url, **kwargs)
+            gcs_url=GCS_URL,
+            major_version_number=MAJOR_VERSION_INT,
+            major_version_path=MAJOR_VERSION_GCS_STR,
+            **storage_kwargs,  # used by simplecache, init_filesystem(url, **kwargs)
         )
 
         # set species analysis version - this is Ag specific currently, hence
@@ -238,7 +239,7 @@ class Ag3(AnophelesDataResource):
             f"Species analysis        : {self._species_analysis}\n"
             f"Site filters analysis   : {self._site_filters_analysis}\n"
             f"Software version        : malariagen_data {malariagen_data.__version__}\n"
-            f"Client location         : {self._client_location}\n"
+            f"Client location         : {self.client_location}\n"
             f"---\n"
             f"Please note that data are subject to terms of use,\n"
             f"for more information see https://www.malariagen.net/data\n"
@@ -308,7 +309,7 @@ class Ag3(AnophelesDataResource):
                         <th style="text-align: left">
                             Client location
                         </th>
-                        <td>{self._client_location}</td>
+                        <td>{self.client_location}</td>
                     </tr>
                 </tbody>
             </table>

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -323,7 +323,7 @@ class Ag3(AnophelesDataResource):
             df = self._cache_species_calls[key]
 
         except KeyError:
-            release = self._lookup_release(sample_set=sample_set)
+            release = self.lookup_release(sample_set=sample_set)
             release_path = self._release_to_path(release)
             path_prefix = f"{self._base_path}/{release_path}/metadata"
             if self._species_analysis == "aim_20220528":
@@ -792,7 +792,7 @@ class Ag3(AnophelesDataResource):
         try:
             return self._cache_cnv_hmm[sample_set]
         except KeyError:
-            release = self._lookup_release(sample_set=sample_set)
+            release = self.lookup_release(sample_set=sample_set)
             release_path = self._release_to_path(release)
             path = f"{self._base_path}/{release_path}/cnv/{sample_set}/hmm/zarr"
             store = init_zarr_store(fs=self._fs, path=path)
@@ -993,7 +993,7 @@ class Ag3(AnophelesDataResource):
         try:
             return self._cache_cnv_coverage_calls[key]
         except KeyError:
-            release = self._lookup_release(sample_set=sample_set)
+            release = self.lookup_release(sample_set=sample_set)
             release_path = self._release_to_path(release)
             path = f"{self._base_path}/{release_path}/cnv/{sample_set}/coverage_calls/{analysis}/zarr"
             # N.B., not all sample_set/analysis combinations exist, need to check
@@ -1181,7 +1181,7 @@ class Ag3(AnophelesDataResource):
         try:
             return self._cache_cnv_discordant_read_calls[sample_set]
         except KeyError:
-            release = self._lookup_release(sample_set=sample_set)
+            release = self.lookup_release(sample_set=sample_set)
             release_path = self._release_to_path(release)
             path = f"{self._base_path}/{release_path}/cnv/{sample_set}/discordant_read_calls/zarr"
             store = init_zarr_store(fs=self._fs, path=path)
@@ -2475,7 +2475,7 @@ class Ag3(AnophelesDataResource):
         return ds.copy(deep=False)
 
     def _aim_calls_dataset(self, *, aims, sample_set):
-        release = self._lookup_release(sample_set=sample_set)
+        release = self.lookup_release(sample_set=sample_set)
         release_path = self._release_to_path(release)
         path = f"gs://vo_agam_release/{release_path}/aim_calls_20220528/{sample_set}/{aims}.zarr"
         store = init_zarr_store(fs=self._fs, path=path)

--- a/malariagen_data/anoph/base.py
+++ b/malariagen_data/anoph/base.py
@@ -1,0 +1,315 @@
+import json
+from collections.abc import Mapping
+from typing import IO, Dict, Optional, Sequence, Tuple, Union
+
+import bokeh.io
+from numpydoc_decorator import doc
+from typing_extensions import Annotated, TypeAlias
+
+from ..util import LoggingHelper, Region, check_colab_location, init_filesystem
+
+
+class base_params:
+    """Parameter definitions common to many functions."""
+
+    contig: TypeAlias = Annotated[
+        str,
+        """
+        Reference genome contig name. See the `contigs` property for valid contig
+        names.
+        """,
+    ]
+    region: TypeAlias = Annotated[
+        Union[str, Region],
+        """
+        Region of the reference genome. Can be a contig name, region string
+        (formatted like "{contig}:{start}-{end}"), or identifier of a genome
+        feature such as a gene or transcript.
+        """,
+    ]
+    release: TypeAlias = Annotated[
+        Union[str, Sequence[str]],
+        "Release version identifier.",
+    ]
+    sample_set: TypeAlias = Annotated[
+        str,
+        "Sample set identifier.",
+    ]
+    sample_sets: TypeAlias = Annotated[
+        Union[Sequence[str], str],
+        """
+        List of sample sets and/or releases. Can also be a single sample set or
+        release.
+        """,
+    ]
+    sample_query: TypeAlias = Annotated[
+        str,
+        """
+        A pandas query string to be evaluated against the sample metadata.
+        """,
+    ]
+    cohort1_query: TypeAlias = Annotated[
+        str,
+        """
+        A pandas query string to be evaluated against the sample metadata,
+        to select samples for the first cohort.
+        """,
+    ]
+    cohort2_query: TypeAlias = Annotated[
+        str,
+        """
+        A pandas query string to be evaluated against the sample metadata,
+        to select samples for the second cohort.
+        """,
+    ]
+    site_mask: TypeAlias = Annotated[
+        str,
+        """
+        Which site filters mask to apply. See the `site_mask_ids` property for
+        available values.
+        """,
+    ]
+    site_class: TypeAlias = Annotated[
+        str,
+        """
+        Select sites belonging to one of the following classes: CDS_DEG_4,
+        (4-fold degenerate coding sites), CDS_DEG_2_SIMPLE (2-fold simple
+        degenerate coding sites), CDS_DEG_0 (non-degenerate coding sites),
+        INTRON_SHORT (introns shorter than 100 bp), INTRON_LONG (introns
+        longer than 200 bp), INTRON_SPLICE_5PRIME (intron within 2 bp of
+        5' splice site), INTRON_SPLICE_3PRIME (intron within 2 bp of 3'
+        splice site), UTR_5PRIME (5' untranslated region), UTR_3PRIME (3'
+        untranslated region), INTERGENIC (intergenic, more than 10 kbp from
+        a gene).
+        """,
+    ]
+    cohort_size: TypeAlias = Annotated[
+        int,
+        """
+        Randomly down-sample to this value if the number of samples in the
+        cohort is greater. Raise an error if the number of samples is less
+        than this value.
+        """,
+    ]
+    min_cohort_size: TypeAlias = Annotated[
+        int,
+        """
+        Minimum cohort size. Raise an error if the number of samples is
+        less than this value.
+        """,
+    ]
+    max_cohort_size: TypeAlias = Annotated[
+        int,
+        """
+        Randomly down-sample to this value if the number of samples in the
+        cohort is greater.
+        """,
+    ]
+    random_seed: TypeAlias = Annotated[
+        int,
+        "Random seed used for reproducible down-sampling.",
+    ]
+    transcript: TypeAlias = Annotated[
+        str,
+        "Gene transcript identifier.",
+    ]
+    cohort: TypeAlias = Annotated[
+        Union[str, Tuple[str, str]],
+        """
+        Either a string giving one of the predefined cohort labels, or a
+        pair of strings giving a custom cohort label and a sample query.
+        """,
+    ]
+    cohorts: TypeAlias = Annotated[
+        Union[str, Mapping[str, str]],
+        """
+        Either a string giving the name of a predefined cohort set (e.g.,
+        "admin1_month") or a dict mapping custom cohort labels to sample
+        queries.
+        """,
+    ]
+    n_jack: TypeAlias = Annotated[
+        int,
+        """
+        Number of blocks to divide the data into for the block jackknife
+        estimation of confidence intervals. N.B., larger is not necessarily
+        better.
+        """,
+    ]
+    confidence_level: TypeAlias = Annotated[
+        float,
+        """
+        Confidence level to use for confidence interval calculation. E.g., 0.95
+        means 95% confidence interval.
+        """,
+    ]
+    field: TypeAlias = Annotated[str, "Name of array or column to access."]
+    inline_array: TypeAlias = Annotated[
+        bool,
+        "Passed through to dask `from_array()`.",
+    ]
+    inline_array_default: inline_array = True
+    chunks: TypeAlias = Annotated[
+        str,
+        """
+        If 'auto' let dask decide chunk size. If 'native' use native zarr
+        chunks. Also, can be a target size, e.g., '200 MiB'.
+        """,
+    ]
+    chunks_default: chunks = "native"
+
+
+class AnophelesBase:
+    def __init__(
+        self,
+        *,
+        url: str,
+        config_path: str,
+        bokeh_output_notebook: bool,
+        log: Union[str, IO],
+        debug: bool,
+        show_progress: bool,
+        check_location: bool,
+        pre: bool,
+        gcs_url: str,
+        major_version_number: int,
+        major_version_path: str,
+        **storage_kwargs,
+    ):
+        self._url = url
+        self._config_path = config_path
+        self._debug = debug
+        self._show_progress = show_progress
+        self._pre = pre
+        self._gcs_url = gcs_url
+        self._major_version_number = major_version_number
+        self._major_version_path = major_version_path
+
+        # Set up logging.
+        self._log = LoggingHelper(name=__name__, out=log, debug=debug)
+
+        # Set up fsspec filesystem.
+        self._fs, self._base_path = init_filesystem(url, **storage_kwargs)
+
+        # Lazily load config.
+        self._config: Optional[Dict] = None
+
+        # Get bokeh to output plots to the notebook - this is a common gotcha,
+        # users forget to do this and wonder why bokeh plots don't show.
+        if bokeh_output_notebook:
+            bokeh.io.output_notebook(hide_banner=True)
+
+        # Check colab location is in the US.
+        if check_location:
+            self._client_details = check_colab_location(
+                gcs_url=self._gcs_url, url=self._url
+            )
+        else:
+            self._client_details = None
+
+        # Set up cache attributes.
+        self._cache_releases: Optional[Tuple[str, ...]] = None
+
+    def open_file(self, path):
+        full_path = f"{self._base_path}/{path}"
+        return self._fs.open(full_path)
+
+    @property
+    def config(self) -> Dict:
+        if self._config is None:
+            with self.open_file(self._config_path) as f:
+                self._config = json.load(f)
+        return self._config.copy()
+
+    # Note regarding release identifiers and storage paths. Within the
+    # data storage, we have used path segments like "v3", "v3.1", "v3.2",
+    # etc., to separate data from different releases. There is an inconsistency
+    # in this convention, because the "v3" should have been "v3.0". To
+    # make the API more consistent, we would like to use consistent release
+    # identifiers like "3.0", "3.1", "3.2", etc., as parameter values and
+    # when release identifiers are added to returned dataframes. In order to
+    # achieve this, below we define two functions that allow mapping between
+    # these consistent release identifiers, and the less consistent release
+    # storage path segments.
+
+    @doc(
+        summary="""
+            Compatibility function, allows us to use release identifiers like "3.0"
+            and "3.1" in the public API, and map these internally into storage path
+            segments.
+        """,
+    )
+    def _release_to_path(self, release: base_params.release) -> str:
+        if release == f"{self._major_version_number}.0":
+            # special case
+            return self._major_version_path
+        elif isinstance(release, str) and release.startswith(
+            f"{self._major_version_number}."
+        ):
+            return f"v{release}"
+        else:
+            raise ValueError(f"Invalid release: {release!r}")
+
+    @doc(
+        summary="""
+            Compatibility function, allows us to use release identifiers like "3.0"
+            and "3.1" in the public API, and map these internally into storage path
+            segments.
+        """,
+        parameters=dict(
+            path="Path segment.",
+        ),
+    )
+    def _path_to_release(self, path: str) -> str:
+        if path == self._major_version_path:
+            return f"{self._major_version_number}.0"
+        elif path.startswith(f"v{self._major_version_number}."):
+            return path[1:]
+        else:
+            raise RuntimeError(f"Unexpected release path: {path!r}")
+
+    def _public_releases(self) -> Tuple[str, ...]:
+        releases = tuple(self.config.get("PUBLIC_RELEASES", ()))
+        return releases
+
+    @doc(
+        summary="""
+            Here we discover which releases are available, by listing the storage
+            directory and examining the subdirectories. This may include "pre-releases"
+            where data may be incomplete.
+        """
+    )
+    def _discover_releases(self) -> Tuple[str, ...]:
+        sub_dirs = [p.split("/")[-1] for p in self._fs.ls(self._base_path)]
+        discovered_releases = tuple(
+            sorted(
+                [
+                    self._path_to_release(d)
+                    for d in sub_dirs
+                    # FIXME: this matches v3 and v3.1, but also v3001.1
+                    if d.startswith(f"v{self._major_version_number}")
+                    and self._fs.exists(f"{self._base_path}/{d}/manifest.tsv")
+                ]
+            )
+        )
+        return discovered_releases
+
+    @property
+    def releases(self) -> Tuple[str, ...]:
+        if self._cache_releases is None:
+            if self._pre:
+                self._cache_releases = self._discover_releases()
+            else:
+                self._cache_releases = self._public_releases()
+        return self._cache_releases
+
+    @property
+    def client_location(self) -> str:
+        details = self._client_details
+        if details is not None:
+            region = details.region
+            country = details.country
+            location = f"{region}, {country}"
+        else:
+            location = "unknown"
+        return location

--- a/malariagen_data/anoph/base.py
+++ b/malariagen_data/anoph/base.py
@@ -1,6 +1,5 @@
 import json
-from collections.abc import Mapping
-from typing import IO, Dict, Optional, Sequence, Tuple, Union
+from typing import IO, Dict, Mapping, Optional, Sequence, Tuple, Union
 
 import bokeh.io
 import pandas as pd

--- a/malariagen_data/util.py
+++ b/malariagen_data/util.py
@@ -7,7 +7,7 @@ import warnings
 from collections.abc import Mapping
 from enum import Enum
 from textwrap import dedent, fill
-from typing import Optional
+from typing import IO, Optional, Union
 from urllib.parse import unquote_plus
 
 try:
@@ -542,7 +542,9 @@ class CacheMiss(Exception):
 
 
 class LoggingHelper:
-    def __init__(self, name, out, debug=False):
+    def __init__(
+        self, *, name: str, out: Optional[Union[str, IO]], debug: bool = False
+    ):
         # set up a logger
         logger = logging.getLogger(name)
         if debug:
@@ -553,11 +555,11 @@ class LoggingHelper:
         self._logger = logger
 
         # set up handler
-        handler = None
-        if isinstance(out, str):
-            handler = logging.FileHandler(out)
-        elif hasattr(out, "write"):
+        handler: Optional[logging.StreamHandler] = None
+        if hasattr(out, "write"):
             handler = logging.StreamHandler(out)
+        elif isinstance(out, str):
+            handler = logging.FileHandler(out)
         self._handler = handler
 
         # configure handler

--- a/tests/anoph/test_base.py
+++ b/tests/anoph/test_base.py
@@ -1,0 +1,61 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+from malariagen_data.anoph.base import AnophelesBase
+
+fixture_dir = Path(__file__).parent.resolve() / "fixture"
+
+
+ag3_url = (fixture_dir / "vo_agam_release").resolve().as_uri()
+ag3_config_path = "v3-config.json"
+ag3_gcs_url = "gs://vo_agam_release/"
+
+ag3_public = AnophelesBase(
+    url=ag3_url,
+    config_path=ag3_config_path,
+    bokeh_output_notebook=False,
+    log=sys.stderr,
+    debug=False,
+    show_progress=False,
+    check_location=False,
+    pre=False,
+    gcs_url=ag3_gcs_url,
+    major_version_number=3,
+    major_version_path="v3",
+)
+
+ag3_pre = AnophelesBase(
+    url=ag3_url,
+    config_path=ag3_config_path,
+    bokeh_output_notebook=False,
+    log=sys.stderr,
+    debug=False,
+    show_progress=False,
+    check_location=False,
+    pre=True,
+    gcs_url=ag3_gcs_url,
+    major_version_number=3,
+    major_version_path="v3",
+)
+
+
+@pytest.mark.parametrize("client", [ag3_public, ag3_pre])
+def test_config(client):
+    config = client.config
+    assert isinstance(config, dict)
+
+
+@pytest.mark.parametrize("client", [ag3_public, ag3_pre])
+def test_releases(client):
+    releases = client.releases
+    assert isinstance(releases, tuple)
+    assert len(releases) > 0
+    assert all([isinstance(r, str) for r in releases])
+
+
+@pytest.mark.parametrize("client", [ag3_public, ag3_pre])
+def test_client_location(client):
+    location = client.client_location
+    assert isinstance(location, str)

--- a/tests/anoph/test_base.py
+++ b/tests/anoph/test_base.py
@@ -7,7 +7,16 @@ import pytest
 
 from malariagen_data.anoph.base import AnophelesBase
 
+# We are going to create some data locally which follows
+# the same layout and format of the real data in GCS,
+# but which is much smaller and so can be used for faster
+# test runs. This data is referred to here as the
+# "data fixture".
+
+# This is the location where the data fixture will be stored.
 fixture_path = Path(__file__).parent.resolve() / "fixture"
+
+# These parameters are for Ag3-style data fixture.
 ag_bucket_name = "vo_agam_release"
 ag_gcs_url = f"gs://{ag_bucket_name}/"
 ag_fixture_path = (fixture_path / ag_bucket_name).resolve()
@@ -15,9 +24,19 @@ ag_fixture_path.mkdir(parents=True, exist_ok=True)
 ag_fixture_url = ag_fixture_path.as_uri()
 ag3_config_path = "v3-config.json"
 
+# These parameters are for Af1-style data fixture.
+af_bucket_name = "vo_afun_release"
+af_gcs_url = f"gs://{af_bucket_name}/"
+af_fixture_path = (fixture_path / af_bucket_name).resolve()
+af_fixture_path.mkdir(parents=True, exist_ok=True)
+af_fixture_url = af_fixture_path.as_uri()
+af1_config_path = "v1.0-config.json"
+
 
 @pytest.fixture(scope="session", autouse=True)
 def ag3_fixture_config(force: bool = False):
+    # Here we create the release config file for an Ag3-style
+    # data fixture.
     config_path = ag_fixture_path / ag3_config_path
     if force or not config_path.exists():
         config = {
@@ -28,7 +47,23 @@ def ag3_fixture_config(force: bool = False):
 
 
 @pytest.fixture(scope="session", autouse=True)
+def af1_fixture_config(force: bool = False):
+    # Here we create the release config file for an Af1-style
+    # data fixture.
+    config_path = af_fixture_path / af1_config_path
+    if force or not config_path.exists():
+        config = {
+            "PUBLIC_RELEASES": ["1.0"],
+        }
+        with config_path.open(mode="w") as f:
+            json.dump(config, f)
+
+
+@pytest.fixture(scope="session", autouse=True)
 def ag3_fixture_public_release_manifest(force: bool = False):
+    # Here we create a release manifest for an Ag3-style
+    # public release. Note this is not the exact same data
+    # as the real release.
     public_release_path = ag_fixture_path / "v3"
     public_release_path.mkdir(parents=True, exist_ok=True)
     public_release_manifest_path = public_release_path / "manifest.tsv"
@@ -45,7 +80,34 @@ def ag3_fixture_public_release_manifest(force: bool = False):
 
 
 @pytest.fixture(scope="session", autouse=True)
+def af1_fixture_public_release_manifest(force: bool = False):
+    # Here we create a release manifest for an Af1-style
+    # public release. Note this is not the exact same data
+    # as the real release.
+    public_release_path = af_fixture_path / "v1.0"
+    public_release_path.mkdir(parents=True, exist_ok=True)
+    public_release_manifest_path = public_release_path / "manifest.tsv"
+    if force or not public_release_manifest_path.exists():
+        public_release_manifest = pd.DataFrame(
+            {
+                "sample_set": [
+                    "1229-VO-GH-DADZIE-VMF00095",
+                    "1230-VO-GA-CF-AYALA-VMF00045",
+                    "1231-VO-MULTI-WONDJI-VMF00043",
+                ],
+                "sample_count": [36, 50, 320],
+            }
+        )
+        public_release_manifest.to_csv(
+            public_release_manifest_path, index=False, sep="\t"
+        )
+
+
+@pytest.fixture(scope="session", autouse=True)
 def ag3_fixture_pre_release_manifest(force: bool = False):
+    # Here we create a release manifest for an Ag3-style
+    # pre-release. Note this is not the exact same data
+    # as the real release.
     pre_release_path = ag_fixture_path / "v3.1"
     pre_release_path.mkdir(parents=True, exist_ok=True)
     pre_release_manifest_path = pre_release_path / "manifest.tsv"
@@ -62,6 +124,10 @@ def ag3_fixture_pre_release_manifest(force: bool = False):
         pre_release_manifest.to_csv(pre_release_manifest_path, index=False, sep="\t")
 
 
+# N.B., we want to test behaviour of the AnophelesBase class
+# both with and without pre-releases.
+
+# Set up using the Ag3-style data fixture and public releases only.
 ag3_public = AnophelesBase(
     url=ag_fixture_url,
     config_path=ag3_config_path,
@@ -76,6 +142,8 @@ ag3_public = AnophelesBase(
     major_version_path="v3",
 )
 ag3_public_param = pytest.param(ag3_public, id="ag3_public")
+
+# Set up using Ag3-style data fixture and pre-releases.
 ag3_pre = AnophelesBase(
     url=ag_fixture_url,
     config_path=ag3_config_path,
@@ -91,14 +159,30 @@ ag3_pre = AnophelesBase(
 )
 ag3_pre_param = pytest.param(ag3_pre, id="ag3_pre")
 
+# Set up using the Af1-style data fixture and public releases only.
+af1_public = AnophelesBase(
+    url=af_fixture_url,
+    config_path=af1_config_path,
+    bokeh_output_notebook=False,
+    log=sys.stderr,
+    debug=True,
+    show_progress=False,
+    check_location=False,
+    pre=False,
+    gcs_url=af_gcs_url,
+    major_version_number=1,
+    major_version_path="v1.0",
+)
+af1_public_param = pytest.param(af1_public, id="af1_public")
 
-@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param])
+
+@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param, af1_public_param])
 def test_config(api):
     config = api.config
     assert isinstance(config, dict)
 
 
-@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param])
+@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param, af1_public_param])
 def test_releases(api):
     releases = api.releases
     assert isinstance(releases, tuple)
@@ -106,13 +190,13 @@ def test_releases(api):
     assert all([isinstance(r, str) for r in releases])
 
 
-@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param])
+@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param, af1_public_param])
 def test_api_location(api):
     location = api.client_location
     assert isinstance(location, str)
 
 
-@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param])
+@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param, af1_public_param])
 def test_sample_sets_default(api):
     df = api.sample_sets()
     assert isinstance(df, pd.DataFrame)
@@ -120,7 +204,7 @@ def test_sample_sets_default(api):
     assert len(df) > 0
 
 
-@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param])
+@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param, af1_public_param])
 def test_sample_sets_specific(api):
     releases = api.releases
     for release in releases:
@@ -130,7 +214,7 @@ def test_sample_sets_specific(api):
         assert len(df) > 0
 
 
-@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param])
+@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param, af1_public_param])
 def test_lookup_release(api):
     releases = api.releases
     for release in releases:

--- a/tests/anoph/test_base.py
+++ b/tests/anoph/test_base.py
@@ -1,61 +1,139 @@
+import json
 import sys
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
 from malariagen_data.anoph.base import AnophelesBase
 
-fixture_dir = Path(__file__).parent.resolve() / "fixture"
-
-
-ag3_url = (fixture_dir / "vo_agam_release").resolve().as_uri()
+fixture_path = Path(__file__).parent.resolve() / "fixture"
+ag_bucket_name = "vo_agam_release"
+ag_gcs_url = f"gs://{ag_bucket_name}/"
+ag_fixture_path = (fixture_path / ag_bucket_name).resolve()
+ag_fixture_path.mkdir(parents=True, exist_ok=True)
+ag_fixture_url = ag_fixture_path.as_uri()
 ag3_config_path = "v3-config.json"
-ag3_gcs_url = "gs://vo_agam_release/"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ag3_fixture_config(force: bool = False):
+    config_path = ag_fixture_path / ag3_config_path
+    if force or not config_path.exists():
+        config = {
+            "PUBLIC_RELEASES": ["3.0"],
+        }
+        with config_path.open(mode="w") as f:
+            json.dump(config, f)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ag3_fixture_public_release_manifest(force: bool = False):
+    public_release_path = ag_fixture_path / "v3"
+    public_release_path.mkdir(parents=True, exist_ok=True)
+    public_release_manifest_path = public_release_path / "manifest.tsv"
+    if force or not public_release_manifest_path.exists():
+        public_release_manifest = pd.DataFrame(
+            {
+                "sample_set": ["AG1000G-AO", "AG1000G-BF-A"],
+                "sample_count": [81, 181],
+            }
+        )
+        public_release_manifest.to_csv(
+            public_release_manifest_path, index=False, sep="\t"
+        )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ag3_fixture_pre_release_manifest(force: bool = False):
+    pre_release_path = ag_fixture_path / "v3.1"
+    pre_release_path.mkdir(parents=True, exist_ok=True)
+    pre_release_manifest_path = pre_release_path / "manifest.tsv"
+    if force or not pre_release_manifest_path.exists():
+        pre_release_manifest = pd.DataFrame(
+            {
+                "sample_set": [
+                    "1177-VO-ML-LEHMANN-VMF00015",
+                    "1237-VO-BJ-DJOGBENOU-VMF00050",
+                ],
+                "sample_count": [23, 90],
+            }
+        )
+        pre_release_manifest.to_csv(pre_release_manifest_path, index=False, sep="\t")
+
 
 ag3_public = AnophelesBase(
-    url=ag3_url,
+    url=ag_fixture_url,
     config_path=ag3_config_path,
     bokeh_output_notebook=False,
     log=sys.stderr,
-    debug=False,
+    debug=True,
     show_progress=False,
     check_location=False,
     pre=False,
-    gcs_url=ag3_gcs_url,
+    gcs_url=ag_gcs_url,
     major_version_number=3,
     major_version_path="v3",
 )
-
+ag3_public_param = pytest.param(ag3_public, id="ag3_public")
 ag3_pre = AnophelesBase(
-    url=ag3_url,
+    url=ag_fixture_url,
     config_path=ag3_config_path,
     bokeh_output_notebook=False,
     log=sys.stderr,
-    debug=False,
+    debug=True,
     show_progress=False,
     check_location=False,
     pre=True,
-    gcs_url=ag3_gcs_url,
+    gcs_url=ag_gcs_url,
     major_version_number=3,
     major_version_path="v3",
 )
+ag3_pre_param = pytest.param(ag3_pre, id="ag3_pre")
 
 
-@pytest.mark.parametrize("client", [ag3_public, ag3_pre])
-def test_config(client):
-    config = client.config
+@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param])
+def test_config(api):
+    config = api.config
     assert isinstance(config, dict)
 
 
-@pytest.mark.parametrize("client", [ag3_public, ag3_pre])
-def test_releases(client):
-    releases = client.releases
+@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param])
+def test_releases(api):
+    releases = api.releases
     assert isinstance(releases, tuple)
     assert len(releases) > 0
     assert all([isinstance(r, str) for r in releases])
 
 
-@pytest.mark.parametrize("client", [ag3_public, ag3_pre])
-def test_client_location(client):
-    location = client.client_location
+@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param])
+def test_api_location(api):
+    location = api.client_location
     assert isinstance(location, str)
+
+
+@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param])
+def test_sample_sets_default(api):
+    df = api.sample_sets()
+    assert isinstance(df, pd.DataFrame)
+    assert df.columns.tolist() == ["sample_set", "sample_count", "release"]
+    assert len(df) > 0
+
+
+@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param])
+def test_sample_sets_specific(api):
+    releases = api.releases
+    for release in releases:
+        df = api.sample_sets(release=release)
+        assert isinstance(df, pd.DataFrame)
+        assert df.columns.tolist() == ["sample_set", "sample_count", "release"]
+        assert len(df) > 0
+
+
+@pytest.mark.parametrize("api", [ag3_public_param, ag3_pre_param])
+def test_lookup_release(api):
+    releases = api.releases
+    for release in releases:
+        df_ss = api.sample_sets(release=release)
+        for s in df_ss["sample_set"]:
+            assert api.lookup_release(s) == release

--- a/tests/test_anopheles.py
+++ b/tests/test_anopheles.py
@@ -58,9 +58,9 @@ def test_sample_sets(subclass, url, release, sample_sets_count):
     assert len(df_sample_sets) == sample_sets_count
     assert tuple(df_sample_sets.columns) == ("sample_set", "sample_count", "release")
 
-    # test duplicates not allowed
-    with pytest.raises(ValueError):
-        anoph.sample_sets(release=[release, release])
+    # test duplicates are handled
+    df_dup = anoph.sample_sets(release=[release, release])
+    assert_frame_equal(df_sample_sets, df_dup)
 
     # test default is all public releases
     df_default = anoph.sample_sets()


### PR DESCRIPTION
This PR begins the work of breaking up the `AnophelesDataResource` class into a number of smaller classes with related and self-contained functionality, as proposed in #366.

Here a new class `AnophelesBase` is created, which assumes responsibility for loading release configuration and accessing release manifests (sample sets).

Note also that some new tests are added which specifically test this new class. These new tests use locally-created data which mimics the organisation and format of data in Ag3 and Af1 but is local and smaller to allow for faster test runs.

Also resolves #368 along the way.