### PR TITLE
Move _prep_sample_sets_param

### DIFF
--- a/tests/anoph/test_base.py
+++ b/tests/anoph/test_base.py
@@ -110,3 +110,46 @@ def test_lookup_release(fixture, api):
         df_ss = api.sample_sets(release=release)
         for s in df_ss["sample_set"]:
             assert api.lookup_release(s) == release
+
+
+def test_prep_sample_sets_param(ag3_sim_api: AnophelesBase):
+    assert ag3_sim_api._prep_sample_sets_param(sample_sets="3.0") == [
+        "AG1000G-AO",
+        "AG1000G-BF-A",
+    ]
+    assert ag3_sim_api._prep_sample_sets_param(sample_sets="3.1") == [
+        "1177-VO-ML-LEHMANN-VMF00015",
+        "1237-VO-BJ-DJOGBENOU-VMF00050",
+    ]
+    assert ag3_sim_api._prep_sample_sets_param(sample_sets=["3.0", "3.1"]) == [
+        "1177-VO-ML-LEHMANN-VMF00015",
+        "1237-VO-BJ-DJOGBENOU-VMF00050",
+        "AG1000G-AO",
+        "AG1000G-BF-A",
+    ]
+    assert ag3_sim_api._prep_sample_sets_param(sample_sets=None) == [
+        "1177-VO-ML-LEHMANN-VMF00015",
+        "1237-VO-BJ-DJOGBENOU-VMF00050",
+        "AG1000G-AO",
+        "AG1000G-BF-A",
+    ]
+    assert ag3_sim_api._prep_sample_sets_param(sample_sets="AG1000G-AO") == [
+        "AG1000G-AO"
+    ]
+    assert ag3_sim_api._prep_sample_sets_param(
+        sample_sets=["AG1000G-AO", "AG1000G-BF-A"]
+    ) == ["AG1000G-AO", "AG1000G-BF-A"]
+    assert ag3_sim_api._prep_sample_sets_param(
+        sample_sets=("AG1000G-AO", "AG1000G-BF-A")
+    ) == ["AG1000G-AO", "AG1000G-BF-A"]
+    assert ag3_sim_api._prep_sample_sets_param(
+        sample_sets=["AG1000G-AO", "AG1000G-BF-A", "AG1000G-AO"]
+    ) == ["AG1000G-AO", "AG1000G-BF-A"]
+    assert ag3_sim_api._prep_sample_sets_param(sample_sets=["3.0", "AG1000G-AO"]) == [
+        "AG1000G-AO",
+        "AG1000G-BF-A",
+    ]
+    with pytest.raises(ValueError):
+        ag3_sim_api._prep_sample_sets_param(sample_sets=["AG1000G-AO", "foobar"])
+    with pytest.raises(TypeError):
+        ag3_sim_api._prep_sample_sets_param(sample_sets=3.1)  # type: ignore

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -1726,12 +1726,17 @@ def test_gene_cnv_frequencies__drop_invariant():
 
 def test_gene_cnv_frequencies__dup_samples():
     ag3 = setup_ag3(cohorts_analysis="20211101")
-    with pytest.raises(ValueError):
-        ag3.gene_cnv_frequencies(
-            region="3L",
-            cohorts="admin1_year",
-            sample_sets=["AG1000G-FR", "AG1000G-FR"],
-        )
+    df_dup = ag3.gene_cnv_frequencies(
+        region="3L",
+        cohorts="admin1_year",
+        sample_sets=["AG1000G-FR", "AG1000G-FR"],
+    )
+    df = ag3.gene_cnv_frequencies(
+        region="3L",
+        cohorts="admin1_year",
+        sample_sets=["AG1000G-FR"],
+    )
+    assert_frame_equal(df, df_dup)
 
 
 def test_gene_cnv_frequencies__multi_contig_x():
@@ -2767,13 +2772,19 @@ def test_gene_cnv_frequencies_advanced__missing_samples():
 
 def test_gene_cnv_frequencies_advanced__dup_samples():
     ag3 = setup_ag3(cohorts_analysis="20211101")
-    with pytest.raises(ValueError):
-        ag3.gene_cnv_frequencies_advanced(
-            region="3L",
-            area_by="admin1_iso",
-            period_by="year",
-            sample_sets=["AG1000G-BF-A", "AG1000G-BF-A"],
-        )
+    ds_dup = ag3.gene_cnv_frequencies_advanced(
+        region="3L",
+        area_by="admin1_iso",
+        period_by="year",
+        sample_sets=["AG1000G-BF-A", "AG1000G-BF-A"],
+    )
+    ds = ag3.gene_cnv_frequencies_advanced(
+        region="3L",
+        area_by="admin1_iso",
+        period_by="year",
+        sample_sets=["AG1000G-BF-A"],
+    )
+    assert ds.dims == ds_dup.dims
 
 
 @pytest.mark.parametrize(

--- a/tests/test_anopheles.py
+++ b/tests/test_anopheles.py
@@ -164,13 +164,18 @@ def test_sample_metadata(subclass, major_release, sample_set, sample_sets):
     assert len(df_samples_multi) == expected_len
 
     # duplicate sample sets
-    with pytest.raises(ValueError):
-        anoph.sample_metadata(sample_sets=[major_release, major_release])
-    with pytest.raises(ValueError):
-        # test_ag3.py used AG1000G-UG here instead of AG1000G-X
-        anoph.sample_metadata(sample_sets=[sample_set, sample_set])
-    with pytest.raises(ValueError):
-        anoph.sample_metadata(sample_sets=[sample_set, major_release])
+    assert_frame_equal(
+        anoph.sample_metadata(sample_sets=[major_release]),
+        anoph.sample_metadata(sample_sets=[major_release, major_release]),
+    )
+    assert_frame_equal(
+        anoph.sample_metadata(sample_sets=[sample_set]),
+        anoph.sample_metadata(sample_sets=[sample_set, sample_set]),
+    )
+    assert_frame_equal(
+        anoph.sample_metadata(sample_sets=[major_release]),
+        anoph.sample_metadata(sample_sets=[major_release, sample_set]),
+    )
 
     # default is all public releases
     df_default = anoph.sample_metadata()

--- a/tests/test_anopheles.py
+++ b/tests/test_anopheles.py
@@ -600,13 +600,19 @@ def test_snp_allele_frequencies__dup_samples(
     transcript,
     sample_set,
 ):
+    # Expect automatically deduplicate any sample sets.
     anoph = setup_subclass_cached(subclass)
-    with pytest.raises(ValueError):
-        anoph.snp_allele_frequencies(
-            transcript=transcript,
-            cohorts="admin1_year",
-            sample_sets=[sample_set, sample_set],
-        )
+    df = anoph.snp_allele_frequencies(
+        transcript=transcript,
+        cohorts="admin1_year",
+        sample_sets=[sample_set],
+    )
+    df_dup = anoph.snp_allele_frequencies(
+        transcript=transcript,
+        cohorts="admin1_year",
+        sample_sets=[sample_set, sample_set],
+    )
+    assert_frame_equal(df, df_dup)
 
 
 @pytest.mark.parametrize(
@@ -658,13 +664,19 @@ def test_snp_allele_frequencies__bad_transcript(
 def test_aa_allele_frequencies__dup_samples(
     subclass, cohorts_analysis, transcript, sample_set
 ):
+    # Expect automatically deduplicate sample sets.
     anoph = setup_subclass_cached(subclass=subclass, cohorts_analysis=cohorts_analysis)
-    with pytest.raises(ValueError):
-        anoph.aa_allele_frequencies(
-            transcript=transcript,
-            cohorts="admin1_year",
-            sample_sets=[sample_set, sample_set],
-        )
+    df = anoph.aa_allele_frequencies(
+        transcript=transcript,
+        cohorts="admin1_year",
+        sample_sets=[sample_set],
+    )
+    df_dup = anoph.aa_allele_frequencies(
+        transcript=transcript,
+        cohorts="admin1_year",
+        sample_sets=[sample_set, sample_set],
+    )
+    assert_frame_equal(df, df_dup)
 
 
 @pytest.mark.parametrize(
@@ -688,13 +700,19 @@ def test_snp_allele_frequencies_advanced__dup_samples(
     subclass, cohorts_analysis, transcript, sample_set
 ):
     anoph = setup_subclass_cached(subclass=subclass, cohorts_analysis=cohorts_analysis)
-    with pytest.raises(ValueError):
-        anoph.snp_allele_frequencies_advanced(
-            transcript=transcript,
-            area_by="admin1_iso",
-            period_by="year",
-            sample_sets=[sample_set, sample_set],
-        )
+    ds = anoph.snp_allele_frequencies_advanced(
+        transcript=transcript,
+        area_by="admin1_iso",
+        period_by="year",
+        sample_sets=[sample_set],
+    )
+    ds_dup = anoph.snp_allele_frequencies_advanced(
+        transcript=transcript,
+        area_by="admin1_iso",
+        period_by="year",
+        sample_sets=[sample_set, sample_set],
+    )
+    assert ds.dims == ds_dup.dims
 
 
 @pytest.mark.parametrize(
@@ -718,13 +736,19 @@ def test_aa_allele_frequencies_advanced__dup_samples(
     subclass, cohorts_analysis, transcript, sample_set
 ):
     anoph = setup_subclass_cached(subclass=subclass, cohorts_analysis=cohorts_analysis)
-    with pytest.raises(ValueError):
-        anoph.aa_allele_frequencies_advanced(
-            transcript=transcript,
-            area_by="admin1_iso",
-            period_by="year",
-            sample_sets=[sample_set, sample_set],
-        )
+    ds_dup = anoph.aa_allele_frequencies_advanced(
+        transcript=transcript,
+        area_by="admin1_iso",
+        period_by="year",
+        sample_sets=[sample_set, sample_set],
+    )
+    ds = anoph.aa_allele_frequencies_advanced(
+        transcript=transcript,
+        area_by="admin1_iso",
+        period_by="year",
+        sample_sets=[sample_set],
+    )
+    assert ds.dims == ds_dup.dims
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Move the _prep_sample_sets_param function to the AnophelesBase class, alongside other functions for handling sample sets and releases.

Along the way, loosen handling of duplicate sample sets.