### PR TITLE
Add quarter cohorts in `read_cohort_metadata()` exceptions

### DIFF
--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -3842,8 +3842,10 @@ class AnophelesDataResource(
                     "taxon",
                     "cohort_admin1_year",
                     "cohort_admin1_month",
+                    "cohort_admin1_quarter",
                     "cohort_admin2_year",
                     "cohort_admin2_month",
+                    "cohort_admin2_quarter",
                 )
 
                 # Get sample ids as an index via general metadata (has caching)

--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -3834,19 +3834,33 @@ class AnophelesDataResource(
                 )
             except Exception:
                 # Specify cohort_cols
-                cohort_cols = (
-                    "country_iso",
-                    "admin1_name",
-                    "admin1_iso",
-                    "admin2_name",
-                    "taxon",
-                    "cohort_admin1_year",
-                    "cohort_admin1_month",
-                    "cohort_admin1_quarter",
-                    "cohort_admin2_year",
-                    "cohort_admin2_month",
-                    "cohort_admin2_quarter",
-                )
+                if self._cohorts_analysis < "20230223":
+                    cohort_cols = (
+                        "country_iso",
+                        "admin1_name",
+                        "admin1_iso",
+                        "admin2_name",
+                        "taxon",
+                        "cohort_admin1_year",
+                        "cohort_admin1_month",
+                        "cohort_admin2_year",
+                        "cohort_admin2_month",
+                    )
+                # cohorts analyses from "20230223" (will) include quarter columns
+                else:
+                    cohort_cols = (
+                        "country_iso",
+                        "admin1_name",
+                        "admin1_iso",
+                        "admin2_name",
+                        "taxon",
+                        "cohort_admin1_year",
+                        "cohort_admin1_month",
+                        "cohort_admin1_quarter",
+                        "cohort_admin2_year",
+                        "cohort_admin2_month",
+                        "cohort_admin2_quarter",
+                    )
 
                 # Get sample ids as an index via general metadata (has caching)
                 df_general = self._read_general_metadata(sample_set=sample_set)

--- a/tests/anoph/conftest.py
+++ b/tests/anoph/conftest.py
@@ -153,10 +153,10 @@ class Gff3Simulator:
                 gene_start = cur_fwd + inter_size
             else:
                 gene_start = cur_rev + inter_size
-            if gene_start >= contig_size:
+            gene_end = gene_start + gene_size
+            if gene_end >= contig_size:
                 # Bail out, no more space left on the contig.
                 return
-            gene_end = min(gene_start + gene_size, contig_size)
             assert gene_end > gene_start
             gene_attrs = f"ID={gene_id}"
             for attr in self.attrs:
@@ -206,7 +206,6 @@ class Gff3Simulator:
         # the same coordinates as the parent gene, which is not strictly
         # accurate in real data.
 
-        gene_size = gene_end - gene_start
         for transcript_ix in range(
             random.randint(self.n_transcripts_low, self.n_transcripts_high)
         ):
@@ -231,7 +230,6 @@ class Gff3Simulator:
                 contig=contig,
                 strand=strand,
                 gene_ix=gene_ix,
-                gene_size=gene_size,
                 transcript_ix=transcript_ix,
                 transcript_id=transcript_id,
                 transcript_start=transcript_start,
@@ -244,7 +242,6 @@ class Gff3Simulator:
         contig,
         strand,
         gene_ix,
-        gene_size,
         transcript_ix,
         transcript_id,
         transcript_start,
@@ -255,12 +252,13 @@ class Gff3Simulator:
         # whereas in the funestus annotations, exons can be shared between
         # transcripts.
 
+        transcript_size = transcript_end - transcript_start
         exons = []
         exon_end = transcript_start
         for exon_ix in range(random.randint(self.n_exons_low, self.n_exons_high)):
             exon_id = f"exon-{contig}-{gene_ix}-{transcript_ix}-{exon_ix}"
             intron_size = random.randint(
-                self.intron_size_low, min(gene_size, self.intron_size_high)
+                self.intron_size_low, min(transcript_size, self.intron_size_high)
             )
             exon_start = exon_end + intron_size
             if exon_start >= transcript_end:


### PR DESCRIPTION
Resolves #384

Added the two new cohorts to the exceptions in `read_cohort_metadata()`. 

As this is in `anopheles.py`, will have to keep in mind that we would expect cohort analysis for quarters in af1 too.  