### PR TITLE
Faster xarray concatenation

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -19,8 +19,8 @@ from .util import (
     DIM_VARIANT,
     Region,
     da_from_zarr,
+    fast_xarray_concat,
     init_zarr_store,
-    xarray_concat,
 )
 
 # silence dask performance warnings
@@ -463,7 +463,7 @@ class Ag3(AnophelesDataResource):
                 chunks=chunks,
             )
 
-            ds = xr.concat([ds_r, ds_l], dim=DIM_VARIANT)
+            ds = fast_xarray_concat([ds_r, ds_l], dim=DIM_VARIANT)
 
             return ds
 
@@ -493,7 +493,7 @@ class Ag3(AnophelesDataResource):
             max_r = super().genome_sequence(region=contig_r).shape[0]
             ds_l["variant_position"] = ds_l["variant_position"] + max_r
 
-            ds = xr.concat([ds_r, ds_l], dim=DIM_VARIANT)
+            ds = fast_xarray_concat([ds_r, ds_l], dim=DIM_VARIANT)
 
             return ds
 
@@ -566,7 +566,7 @@ class Ag3(AnophelesDataResource):
             if ds_l is not None:
                 max_r = super().genome_sequence(region=contig_r).shape[0]
                 ds_l["variant_position"] = ds_l["variant_position"] + max_r
-                ds = xr.concat([ds_r, ds_l], dim=DIM_VARIANT)
+                ds = fast_xarray_concat([ds_r, ds_l], dim=DIM_VARIANT)
                 return ds
 
             return None
@@ -735,7 +735,7 @@ class Ag3(AnophelesDataResource):
                 ly.append(y)
 
             debug("concatenate data from multiple sample sets")
-            x = xarray_concat(ly, dim=DIM_SAMPLE)
+            x = fast_xarray_concat(ly, dim=DIM_SAMPLE)
 
             debug("handle region, do this only once - optimisation")
             if r.start is not None or r.end is not None:
@@ -750,7 +750,7 @@ class Ag3(AnophelesDataResource):
             lx.append(x)
 
         debug("concatenate data from multiple regions")
-        ds = xarray_concat(lx, dim=DIM_VARIANT)
+        ds = fast_xarray_concat(lx, dim=DIM_VARIANT)
 
         debug("handle sample query")
         if sample_query is not None:
@@ -964,7 +964,7 @@ class Ag3(AnophelesDataResource):
                 x = x.isel(variants=loc_region)
 
             lx.append(x)
-        ds = xarray_concat(lx, dim=DIM_VARIANT)
+        ds = fast_xarray_concat(lx, dim=DIM_VARIANT)
 
         return ds
 
@@ -1122,10 +1122,10 @@ class Ag3(AnophelesDataResource):
                 )
                 ly.append(y)
 
-            x = xarray_concat(ly, dim=DIM_SAMPLE)
+            x = fast_xarray_concat(ly, dim=DIM_SAMPLE)
             lx.append(x)
 
-        ds = xarray_concat(lx, dim=DIM_VARIANT)
+        ds = fast_xarray_concat(lx, dim=DIM_VARIANT)
 
         return ds
 
@@ -1167,7 +1167,7 @@ class Ag3(AnophelesDataResource):
         if isinstance(region, Region):
             region = [region]
 
-        ds = xarray_concat(
+        ds = fast_xarray_concat(
             [
                 self._gene_cnv(
                     region=r,
@@ -1557,7 +1557,7 @@ class Ag3(AnophelesDataResource):
         if isinstance(region, Region):
             region = [region]
 
-        ds = xarray_concat(
+        ds = fast_xarray_concat(
             [
                 self._gene_cnv_frequencies_advanced(
                     region=r,
@@ -2327,7 +2327,7 @@ class Ag3(AnophelesDataResource):
             ly.append(y)
 
         debug("concatenate data from multiple sample sets")
-        ds = xarray_concat(ly, dim=DIM_SAMPLE)
+        ds = fast_xarray_concat(ly, dim=DIM_SAMPLE)
 
         debug("handle sample query")
         if sample_query is not None:

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -19,8 +19,8 @@ from .util import (
     DIM_VARIANT,
     Region,
     da_from_zarr,
-    fast_xarray_concat,
     init_zarr_store,
+    simple_xarray_concat,
 )
 
 # silence dask performance warnings
@@ -463,7 +463,7 @@ class Ag3(AnophelesDataResource):
                 chunks=chunks,
             )
 
-            ds = fast_xarray_concat([ds_r, ds_l], dim=DIM_VARIANT)
+            ds = simple_xarray_concat([ds_r, ds_l], dim=DIM_VARIANT)
 
             return ds
 
@@ -493,7 +493,7 @@ class Ag3(AnophelesDataResource):
             max_r = super().genome_sequence(region=contig_r).shape[0]
             ds_l["variant_position"] = ds_l["variant_position"] + max_r
 
-            ds = fast_xarray_concat([ds_r, ds_l], dim=DIM_VARIANT)
+            ds = simple_xarray_concat([ds_r, ds_l], dim=DIM_VARIANT)
 
             return ds
 
@@ -566,7 +566,7 @@ class Ag3(AnophelesDataResource):
             if ds_l is not None:
                 max_r = super().genome_sequence(region=contig_r).shape[0]
                 ds_l["variant_position"] = ds_l["variant_position"] + max_r
-                ds = fast_xarray_concat([ds_r, ds_l], dim=DIM_VARIANT)
+                ds = simple_xarray_concat([ds_r, ds_l], dim=DIM_VARIANT)
                 return ds
 
             return None
@@ -735,7 +735,7 @@ class Ag3(AnophelesDataResource):
                 ly.append(y)
 
             debug("concatenate data from multiple sample sets")
-            x = fast_xarray_concat(ly, dim=DIM_SAMPLE)
+            x = simple_xarray_concat(ly, dim=DIM_SAMPLE)
 
             debug("handle region, do this only once - optimisation")
             if r.start is not None or r.end is not None:
@@ -750,7 +750,7 @@ class Ag3(AnophelesDataResource):
             lx.append(x)
 
         debug("concatenate data from multiple regions")
-        ds = fast_xarray_concat(lx, dim=DIM_VARIANT)
+        ds = simple_xarray_concat(lx, dim=DIM_VARIANT)
 
         debug("handle sample query")
         if sample_query is not None:
@@ -964,7 +964,7 @@ class Ag3(AnophelesDataResource):
                 x = x.isel(variants=loc_region)
 
             lx.append(x)
-        ds = fast_xarray_concat(lx, dim=DIM_VARIANT)
+        ds = simple_xarray_concat(lx, dim=DIM_VARIANT)
 
         return ds
 
@@ -1122,10 +1122,10 @@ class Ag3(AnophelesDataResource):
                 )
                 ly.append(y)
 
-            x = fast_xarray_concat(ly, dim=DIM_SAMPLE)
+            x = simple_xarray_concat(ly, dim=DIM_SAMPLE)
             lx.append(x)
 
-        ds = fast_xarray_concat(lx, dim=DIM_VARIANT)
+        ds = simple_xarray_concat(lx, dim=DIM_VARIANT)
 
         return ds
 
@@ -1167,7 +1167,7 @@ class Ag3(AnophelesDataResource):
         if isinstance(region, Region):
             region = [region]
 
-        ds = fast_xarray_concat(
+        ds = simple_xarray_concat(
             [
                 self._gene_cnv(
                     region=r,
@@ -1557,7 +1557,7 @@ class Ag3(AnophelesDataResource):
         if isinstance(region, Region):
             region = [region]
 
-        ds = fast_xarray_concat(
+        ds = simple_xarray_concat(
             [
                 self._gene_cnv_frequencies_advanced(
                     region=r,
@@ -2327,7 +2327,7 @@ class Ag3(AnophelesDataResource):
             ly.append(y)
 
         debug("concatenate data from multiple sample sets")
-        ds = fast_xarray_concat(ly, dim=DIM_SAMPLE)
+        ds = simple_xarray_concat(ly, dim=DIM_SAMPLE)
 
         debug("handle sample query")
         if sample_query is not None:

--- a/malariagen_data/amin1.py
+++ b/malariagen_data/amin1.py
@@ -11,12 +11,12 @@ from .util import (
     Region,
     da_from_zarr,
     dask_compress_dataset,
-    fast_xarray_concat,
     init_filesystem,
     init_zarr_store,
     locate_region,
     read_gff3,
     resolve_region,
+    simple_xarray_concat,
     unpack_gff3_attributes,
 )
 
@@ -265,7 +265,7 @@ class Amin1:
             )
             for r in region
         ]
-        ds = fast_xarray_concat(
+        ds = simple_xarray_concat(
             datasets,
             dim=DIM_VARIANT,
         )

--- a/malariagen_data/amin1.py
+++ b/malariagen_data/amin1.py
@@ -11,13 +11,13 @@ from .util import (
     Region,
     da_from_zarr,
     dask_compress_dataset,
+    fast_xarray_concat,
     init_filesystem,
     init_zarr_store,
     locate_region,
     read_gff3,
     resolve_region,
     unpack_gff3_attributes,
-    xarray_concat,
 )
 
 GENOME_FEATURES_GFF3_PATH = (
@@ -265,13 +265,9 @@ class Amin1:
             )
             for r in region
         ]
-        ds = xarray_concat(
+        ds = fast_xarray_concat(
             datasets,
             dim=DIM_VARIANT,
-            data_vars="minimal",
-            coords="minimal",
-            compat="override",
-            join="override",
         )
 
         # apply site filters

--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -40,6 +40,7 @@ from .util import (
     da_compress,
     da_from_zarr,
     dask_compress_dataset,
+    fast_xarray_concat,
     hash_params,
     init_zarr_store,
     jackknife_ci,
@@ -48,7 +49,6 @@ from .util import (
     plotly_discrete_legend,
     resolve_region,
     type_error,
-    xarray_concat,
 )
 
 AA_CHANGE_QUERY = (
@@ -1956,7 +1956,7 @@ class AnophelesDataResource(
                 ly.append(y)
 
             debug("concatenate data from multiple sample sets")
-            x = xarray_concat(ly, dim=DIM_SAMPLE)
+            x = fast_xarray_concat(ly, dim=DIM_SAMPLE)
 
             debug("add variants variables")
             v = self._snp_variants_for_contig(
@@ -1982,7 +1982,7 @@ class AnophelesDataResource(
             lx.append(x)
 
         debug("concatenate data from multiple regions")
-        ds = xarray_concat(lx, dim=DIM_VARIANT)
+        ds = fast_xarray_concat(lx, dim=DIM_VARIANT)
 
         if site_mask is not None:
             debug("apply site filters")
@@ -2114,7 +2114,7 @@ class AnophelesDataResource(
             lx.append(x)
 
         debug("concatenate data from multiple regions")
-        ds = xarray_concat(lx, dim=DIM_VARIANT)
+        ds = fast_xarray_concat(lx, dim=DIM_VARIANT)
 
         debug("apply site filters")
         if site_mask is not None:
@@ -5285,7 +5285,7 @@ class AnophelesDataResource(
                 return None
 
             debug("concatenate data from multiple sample sets")
-            x = xarray_concat(ly, dim=DIM_SAMPLE)
+            x = fast_xarray_concat(ly, dim=DIM_SAMPLE)
 
             debug("handle region")
             if r.start or r.end:
@@ -5296,7 +5296,7 @@ class AnophelesDataResource(
             lx.append(x)
 
         debug("concatenate data from multiple regions")
-        ds = xarray_concat(lx, dim=DIM_VARIANT)
+        ds = fast_xarray_concat(lx, dim=DIM_VARIANT)
 
         debug("handle sample query")
         if sample_query is not None:

--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -40,7 +40,6 @@ from .util import (
     da_compress,
     da_from_zarr,
     dask_compress_dataset,
-    fast_xarray_concat,
     hash_params,
     init_zarr_store,
     jackknife_ci,
@@ -48,6 +47,7 @@ from .util import (
     locate_region,
     plotly_discrete_legend,
     resolve_region,
+    simple_xarray_concat,
     type_error,
 )
 
@@ -1956,7 +1956,7 @@ class AnophelesDataResource(
                 ly.append(y)
 
             debug("concatenate data from multiple sample sets")
-            x = fast_xarray_concat(ly, dim=DIM_SAMPLE)
+            x = simple_xarray_concat(ly, dim=DIM_SAMPLE)
 
             debug("add variants variables")
             v = self._snp_variants_for_contig(
@@ -1982,7 +1982,7 @@ class AnophelesDataResource(
             lx.append(x)
 
         debug("concatenate data from multiple regions")
-        ds = fast_xarray_concat(lx, dim=DIM_VARIANT)
+        ds = simple_xarray_concat(lx, dim=DIM_VARIANT)
 
         if site_mask is not None:
             debug("apply site filters")
@@ -2114,7 +2114,7 @@ class AnophelesDataResource(
             lx.append(x)
 
         debug("concatenate data from multiple regions")
-        ds = fast_xarray_concat(lx, dim=DIM_VARIANT)
+        ds = simple_xarray_concat(lx, dim=DIM_VARIANT)
 
         debug("apply site filters")
         if site_mask is not None:
@@ -5285,7 +5285,7 @@ class AnophelesDataResource(
                 return None
 
             debug("concatenate data from multiple sample sets")
-            x = fast_xarray_concat(ly, dim=DIM_SAMPLE)
+            x = simple_xarray_concat(ly, dim=DIM_SAMPLE)
 
             debug("handle region")
             if r.start or r.end:
@@ -5296,7 +5296,7 @@ class AnophelesDataResource(
             lx.append(x)
 
         debug("concatenate data from multiple regions")
-        ds = fast_xarray_concat(lx, dim=DIM_VARIANT)
+        ds = simple_xarray_concat(lx, dim=DIM_VARIANT)
 
         debug("handle sample query")
         if sample_query is not None:

--- a/malariagen_data/util.py
+++ b/malariagen_data/util.py
@@ -471,7 +471,7 @@ def locate_region(region, pos):
     return loc_region
 
 
-def fast_xarray_concat_arrays(datasets, names, dim):
+def _fast_xarray_concat_arrays(datasets, names, dim):
     ds0 = datasets[0]
     out = dict()
     for k in names:
@@ -489,16 +489,18 @@ def fast_xarray_concat_arrays(datasets, names, dim):
     return out
 
 
-def fast_xarray_concat(datasets, dim, attrs=None):
+def fast_xarray_concat(datasets, dim, attrs="override"):
     ds0 = datasets[0]
+    if attrs == "override":
+        attrs = ds0.attrs
     if len(datasets) == 1:
         return ds0
-    coords = fast_xarray_concat_arrays(
+    coords = _fast_xarray_concat_arrays(
         datasets=datasets,
         names=list(ds0.coords),
         dim=dim,
     )
-    data_vars = fast_xarray_concat_arrays(
+    data_vars = _fast_xarray_concat_arrays(
         datasets=datasets,
         names=list(ds0.data_vars),
         dim=dim,

--- a/malariagen_data/util.py
+++ b/malariagen_data/util.py
@@ -4,10 +4,9 @@ import logging
 import re
 import sys
 import warnings
-from collections.abc import Mapping
 from enum import Enum
 from textwrap import dedent, fill
-from typing import IO, Dict, Hashable, List, Optional, Tuple, Union
+from typing import IO, Dict, Hashable, List, Mapping, Optional, Tuple, Union
 from urllib.parse import unquote_plus
 
 try:


### PR DESCRIPTION
There is something funny going on within the xarray concat() function which is causing a big slowdown when we try to concatenate datasets, such as the datasets that are being concatenated internally within the snp_calls() or haplotypes() functions. A lot of time is being spent within [this list comprehension in particular](https://github.com/pydata/xarray/blob/51554f2638bc9e4a527492136fe6f54584ffa75d/xarray/core/concat.py#L584) and the logic of it doesn't look right (pathological for large dimensions?).

In the mean time, this PR hacks a cut down version of concatenating datasets along a dimension, which is much much faster (like 1000X).
