### PR TITLE
Use webgl for bokeh genome plots

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -1741,6 +1741,7 @@ class Ag3(AnophelesDataResource):
         line_kwargs=None,
         show=True,
         x_range=None,
+        output_backend="webgl",
     ):
         """Plot CNV HMM data for a single sample, using bokeh.
 
@@ -1833,13 +1834,14 @@ class Ag3(AnophelesDataResource):
             toolbar_location="above",
             x_range=x_range,
             y_range=(0, y_max),
+            output_backend=output_backend,
         )
 
         debug("plot the normalised coverage data")
         if circle_kwargs is None:
             circle_kwargs = dict()
         circle_kwargs.setdefault("size", 3)
-        circle_kwargs.setdefault("line_width", 0.5)
+        circle_kwargs.setdefault("line_width", 1)
         circle_kwargs.setdefault("line_color", "black")
         circle_kwargs.setdefault("fill_color", None)
         circle_kwargs.setdefault("legend_label", "Coverage")
@@ -1877,6 +1879,7 @@ class Ag3(AnophelesDataResource):
         circle_kwargs=None,
         line_kwargs=None,
         show=True,
+        output_backend="webgl",
     ):
         """Plot CNV HMM data for a single sample, together with a genes track,
         using bokeh.
@@ -1926,6 +1929,7 @@ class Ag3(AnophelesDataResource):
             circle_kwargs=circle_kwargs,
             line_kwargs=line_kwargs,
             show=False,
+            output_backend=output_backend,
         )
         fig1.xaxis.visible = False
 
@@ -1937,6 +1941,7 @@ class Ag3(AnophelesDataResource):
             height=genes_height,
             x_range=fig1.x_range,
             show=False,
+            output_backend=output_backend,
         )
 
         debug("combine plots into a single figure")
@@ -1965,6 +1970,7 @@ class Ag3(AnophelesDataResource):
         row_height=7,
         height=None,
         show=True,
+        output_backend="webgl",
     ):
         """Plot CNV HMM data for multiple samples as a heatmap, using bokeh.
 
@@ -2065,6 +2071,7 @@ class Ag3(AnophelesDataResource):
             x_range=bkmod.Range1d(x_min, x_max, bounds="auto"),
             y_range=(-0.5, n_samples - 0.5),
             tooltips=tooltips,
+            output_backend=output_backend,
         )
 
         debug("set up palette and color mapping")

--- a/malariagen_data/anoph/genome_features.py
+++ b/malariagen_data/anoph/genome_features.py
@@ -153,7 +153,7 @@ class AnophelesGenomeFeaturesData(AnophelesGenomeSequenceData):
         transcript: base_params.transcript,
         sizing_mode: gplt_params.sizing_mode = gplt_params.sizing_mode_default,
         width: gplt_params.width = gplt_params.width_default,
-        height: gplt_params.height = gplt_params.genes_height_default,
+        height: gplt_params.height = 100,
         show: gplt_params.show = True,
         x_range: Optional[gplt_params.x_range] = None,
         toolbar_location: Optional[
@@ -292,13 +292,14 @@ class AnophelesGenomeFeaturesData(AnophelesGenomeSequenceData):
         region: base_params.single_region,
         sizing_mode: gplt_params.sizing_mode = gplt_params.sizing_mode_default,
         width: gplt_params.width = gplt_params.width_default,
-        height: gplt_params.genes_height = gplt_params.genes_height_default,
+        height: gplt_params.genes_height = 120,
         show: gplt_params.show = True,
         toolbar_location: Optional[
             gplt_params.toolbar_location
         ] = gplt_params.toolbar_location_default,
         x_range: Optional[gplt_params.x_range] = None,
-        title: gplt_params.title = "Genes",
+        title: Optional[gplt_params.title] = None,
+        output_backend: gplt_params.output_backend = gplt_params.output_backend_default,
     ) -> gplt_params.figure:
         debug = self._log.debug
 
@@ -355,6 +356,7 @@ class AnophelesGenomeFeaturesData(AnophelesGenomeSequenceData):
             tooltips=tooltips,
             x_range=x_range,
             y_range=bokeh.models.Range1d(-0.4, 2.2),
+            output_backend=output_backend,
         )
 
         debug("add functionality to click through to vectorbase")
@@ -369,8 +371,7 @@ class AnophelesGenomeFeaturesData(AnophelesGenomeSequenceData):
             left="start",
             right="end",
             source=data,
-            line_width=0.5,
-            fill_alpha=0.5,
+            line_width=0,
         )
 
         debug("tidy up the plot")
@@ -379,6 +380,7 @@ class AnophelesGenomeFeaturesData(AnophelesGenomeSequenceData):
         yticklabels = ["-", "+"]
         fig.yaxis.ticker = yticks
         fig.yaxis.major_label_overrides = {k: v for k, v in zip(yticks, yticklabels)}
+        fig.yaxis.axis_label = "Genes"
         self._bokeh_style_genome_xaxis(fig, contig)
 
         if show:

--- a/malariagen_data/anoph/gplt_params.py
+++ b/malariagen_data/anoph/gplt_params.py
@@ -46,7 +46,7 @@ genes_height: TypeAlias = Annotated[
     "Genes track height in pixels (px).",
 ]
 
-genes_height_default: genes_height = 120
+genes_height_default: genes_height = 90
 
 show: TypeAlias = Annotated[
     bool,
@@ -77,3 +77,14 @@ figure: TypeAlias = Annotated[
     Optional[bokeh.model.Model],
     "A bokeh figure (only returned if show=False).",
 ]
+
+output_backend: TypeAlias = Annotated[
+    Literal["canvas", "webgl", "svg"],
+    """
+    Specify an output backend to render a plot area onto. See also
+    https://docs.bokeh.org/en/latest/docs/user_guide/output/webgl.html
+    """,
+]
+
+# webgl is better for plots like selection scans with lots of points
+output_backend_default: output_backend = "webgl"

--- a/malariagen_data/anoph/snp_data.py
+++ b/malariagen_data/anoph/snp_data.py
@@ -1098,6 +1098,7 @@ class AnophelesSnpData(
         max_snps: int = 200_000,
         x_range: Optional[gplt_params.x_range] = None,
         show: gplt_params.show = True,
+        output_backend: gplt_params.output_backend = gplt_params.output_backend_default,
     ) -> gplt_params.figure:
         site_mask = self._prep_site_mask_param(site_mask=site_mask)
 
@@ -1198,6 +1199,7 @@ class AnophelesSnpData(
             x_range=x_range,
             y_range=(0.5, 2.5),
             tooltips=tooltips,
+            output_backend=output_backend,
         )
         hover_tool = fig.select(type=bokeh.models.HoverTool)
         hover_tool.name = "snps"
@@ -1214,6 +1216,7 @@ class AnophelesSnpData(
             color="#cccccc",
             source=df_n_runs,
             name="gaps",
+            line_width=0,
         )
 
         # Plot SNPs.

--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -1093,6 +1093,7 @@ class AnophelesDataResource(
         circle_kwargs,
         show,
         x_range,
+        output_backend,
     ):
         debug = self._log.debug
 
@@ -1129,6 +1130,7 @@ class AnophelesDataResource(
             toolbar_location="above",
             x_range=x_range,
             y_range=(0, y_max),
+            output_backend=output_backend,
         )
 
         debug("plot heterozygosity")
@@ -1140,7 +1142,8 @@ class AnophelesDataResource(
         )
         if circle_kwargs is None:
             circle_kwargs = dict()
-        circle_kwargs.setdefault("size", 3)
+        circle_kwargs.setdefault("size", 4)
+        circle_kwargs.setdefault("line_width", 0)
         fig.circle(x="position", y="heterozygosity", source=data, **circle_kwargs)
 
         debug("tidy up the plot")
@@ -1170,6 +1173,7 @@ class AnophelesDataResource(
         height: gplt_params.height = 200,
         show: gplt_params.show = True,
         x_range: Optional[gplt_params.x_range] = None,
+        output_backend: gplt_params.output_backend = gplt_params.output_backend_default,
     ) -> gplt_params.figure:
         debug = self._log.debug
 
@@ -1201,6 +1205,7 @@ class AnophelesDataResource(
             circle_kwargs=circle_kwargs,
             show=show,
             x_range=x_range,
+            output_backend=output_backend,
         )
 
         if show:
@@ -1227,6 +1232,7 @@ class AnophelesDataResource(
         track_height: gplt_params.track_height = 170,
         genes_height: gplt_params.genes_height = gplt_params.genes_height_default,
         show: gplt_params.show = True,
+        output_backend: gplt_params.output_backend = gplt_params.output_backend_default,
     ) -> gplt_params.figure:
         debug = self._log.debug
 
@@ -1249,6 +1255,7 @@ class AnophelesDataResource(
             height=track_height,
             circle_kwargs=circle_kwargs,
             show=False,
+            output_backend=output_backend,
         )
         fig1.xaxis.visible = False
         figs = [fig1]
@@ -1268,6 +1275,7 @@ class AnophelesDataResource(
                 circle_kwargs=circle_kwargs,
                 show=False,
                 x_range=fig1.x_range,
+                output_backend=output_backend,
             )
             fig_het.xaxis.visible = False
             figs.append(fig_het)
@@ -1280,6 +1288,7 @@ class AnophelesDataResource(
             height=genes_height,
             x_range=fig1.x_range,
             show=False,
+            output_backend=output_backend,
         )
         figs.append(fig_genes)
 
@@ -1400,10 +1409,11 @@ class AnophelesDataResource(
         region: base_params.single_region,
         sizing_mode: gplt_params.sizing_mode = gplt_params.sizing_mode_default,
         width: gplt_params.width = gplt_params.width_default,
-        height: gplt_params.height = 100,
+        height: gplt_params.height = 80,
         show: gplt_params.show = True,
         x_range: Optional[gplt_params.x_range] = None,
-        title: gplt_params.title = "Runs of homozygosity",
+        title: Optional[gplt_params.title] = None,
+        output_backend: gplt_params.output_backend = gplt_params.output_backend_default,
     ) -> gplt_params.figure:
         debug = self._log.debug
 
@@ -1451,6 +1461,7 @@ class AnophelesDataResource(
             active_drag="xpan",
             x_range=x_range,
             y_range=bokeh.models.Range1d(0, 1),
+            output_backend=output_backend,
         )
 
         debug("now plot the ROH as rectangles")
@@ -1460,13 +1471,14 @@ class AnophelesDataResource(
             left="roh_start",
             right="roh_stop",
             source=data,
-            line_width=0.5,
+            line_width=1,
             fill_alpha=0.5,
         )
 
         debug("tidy up the plot")
         fig.ygrid.visible = False
         fig.yaxis.ticker = []
+        fig.yaxis.axis_label = "RoH"
         self._bokeh_style_genome_xaxis(fig, resolved_region.contig)
 
         if show:
@@ -1496,10 +1508,11 @@ class AnophelesDataResource(
         sizing_mode: gplt_params.sizing_mode = gplt_params.sizing_mode_default,
         width: gplt_params.width = gplt_params.width_default,
         heterozygosity_height: gplt_params.height = 170,
-        roh_height: gplt_params.height = 50,
+        roh_height: gplt_params.height = 40,
         genes_height: gplt_params.genes_height = gplt_params.genes_height_default,
         circle_kwargs: Optional[het_params.circle_kwargs] = None,
         show: gplt_params.show = True,
+        output_backend: gplt_params.output_backend = gplt_params.output_backend_default,
     ) -> gplt_params.figure:
         debug = self._log.debug
 
@@ -1530,6 +1543,7 @@ class AnophelesDataResource(
             circle_kwargs=circle_kwargs,
             show=False,
             x_range=None,
+            output_backend=output_backend,
         )
         fig_het.xaxis.visible = False
         figs = [fig_het]
@@ -1555,6 +1569,7 @@ class AnophelesDataResource(
             height=roh_height,
             show=False,
             x_range=fig_het.x_range,
+            output_backend=output_backend,
         )
         fig_roh.xaxis.visible = False
         figs.append(fig_roh)
@@ -1567,6 +1582,7 @@ class AnophelesDataResource(
             height=genes_height,
             x_range=fig_het.x_range,
             show=False,
+            output_backend=output_backend,
         )
         figs.append(fig_genes)
 
@@ -3229,6 +3245,7 @@ class AnophelesDataResource(
         height: gplt_params.height = 200,
         show: gplt_params.show = True,
         x_range: Optional[gplt_params.x_range] = None,
+        output_backend: gplt_params.output_backend = gplt_params.output_backend_default,
     ) -> gplt_params.figure:
         # compute Fst
         x, fst = self.fst_gwss(
@@ -3267,6 +3284,7 @@ class AnophelesDataResource(
             toolbar_location="above",
             x_range=x_range,
             y_range=(0, 1),
+            output_backend=output_backend,
         )
 
         # plot Fst
@@ -3274,7 +3292,7 @@ class AnophelesDataResource(
             x=x,
             y=fst,
             size=3,
-            line_width=0.5,
+            line_width=1,
             line_color="black",
             fill_color=None,
         )
@@ -3319,6 +3337,7 @@ class AnophelesDataResource(
         track_height: gplt_params.track_height = 190,
         genes_height: gplt_params.genes_height = gplt_params.genes_height_default,
         show: gplt_params.show = True,
+        output_backend: gplt_params.output_backend = gplt_params.output_backend_default,
     ) -> gplt_params.figure:
         # gwss track
         fig1 = self.plot_fst_gwss_track(
@@ -3337,6 +3356,7 @@ class AnophelesDataResource(
             width=width,
             height=track_height,
             show=False,
+            output_backend=output_backend,
         )
 
         fig1.xaxis.visible = False
@@ -3349,6 +3369,7 @@ class AnophelesDataResource(
             height=genes_height,
             x_range=fig1.x_range,
             show=False,
+            output_backend=output_backend,
         )
 
         # combine plots into a single figure
@@ -3659,6 +3680,7 @@ class AnophelesDataResource(
         height: gplt_params.height = 200,
         show: gplt_params.show = True,
         x_range: Optional[gplt_params.x_range] = None,
+        output_backend: gplt_params.output_backend = gplt_params.output_backend_default,
     ) -> gplt_params.figure:
         # compute H12
         x, h12 = self.h12_gwss(
@@ -3696,6 +3718,7 @@ class AnophelesDataResource(
             toolbar_location="above",
             x_range=x_range,
             y_range=(0, 1),
+            output_backend=output_backend,
         )
 
         # plot H12
@@ -3703,7 +3726,7 @@ class AnophelesDataResource(
             x=x,
             y=h12,
             size=3,
-            line_width=0.5,
+            line_width=1,
             line_color="black",
             fill_color=None,
         )
@@ -3744,6 +3767,7 @@ class AnophelesDataResource(
         track_height: gplt_params.track_height = 170,
         genes_height: gplt_params.genes_height = gplt_params.genes_height_default,
         show: gplt_params.show = True,
+        output_backend: gplt_params.output_backend = gplt_params.output_backend_default,
     ) -> gplt_params.figure:
         # gwss track
         fig1 = self.plot_h12_gwss_track(
@@ -3761,6 +3785,7 @@ class AnophelesDataResource(
             width=width,
             height=track_height,
             show=False,
+            output_backend=output_backend,
         )
 
         fig1.xaxis.visible = False
@@ -3773,6 +3798,7 @@ class AnophelesDataResource(
             height=genes_height,
             x_range=fig1.x_range,
             show=False,
+            output_backend=output_backend,
         )
 
         # combine plots into a single figure
@@ -3933,6 +3959,7 @@ class AnophelesDataResource(
         height: gplt_params.height = 200,
         show: gplt_params.show = True,
         x_range: Optional[gplt_params.x_range] = None,
+        output_backend: gplt_params.output_backend = gplt_params.output_backend_default,
     ) -> gplt_params.figure:
         # compute H1X
         x, h1x = self.h1x_gwss(
@@ -3971,6 +3998,7 @@ class AnophelesDataResource(
             toolbar_location="above",
             x_range=x_range,
             y_range=(0, 1),
+            output_backend=output_backend,
         )
 
         # plot H1X
@@ -3978,7 +4006,7 @@ class AnophelesDataResource(
             x=x,
             y=h1x,
             size=3,
-            line_width=0.5,
+            line_width=1,
             line_color="black",
             fill_color=None,
         )
@@ -4023,6 +4051,7 @@ class AnophelesDataResource(
         track_height: gplt_params.track_height = 190,
         genes_height: gplt_params.genes_height = gplt_params.genes_height_default,
         show: gplt_params.show = True,
+        output_backend: gplt_params.output_backend = gplt_params.output_backend_default,
     ) -> gplt_params.figure:
         # gwss track
         fig1 = self.plot_h1x_gwss_track(
@@ -4041,6 +4070,7 @@ class AnophelesDataResource(
             width=width,
             height=track_height,
             show=False,
+            output_backend=output_backend,
         )
 
         fig1.xaxis.visible = False
@@ -4053,6 +4083,7 @@ class AnophelesDataResource(
             height=genes_height,
             x_range=fig1.x_range,
             show=False,
+            output_backend=output_backend,
         )
 
         # combine plots into a single figure
@@ -4273,6 +4304,7 @@ class AnophelesDataResource(
         height: gplt_params.height = 200,
         show: gplt_params.show = True,
         x_range: Optional[gplt_params.x_range] = None,
+        output_backend: gplt_params.output_backend = gplt_params.output_backend_default,
     ) -> gplt_params.figure:
         # compute ihs
         x, ihs = self.ihs_gwss(
@@ -4320,31 +4352,39 @@ class AnophelesDataResource(
             height=height,
             toolbar_location="above",
             x_range=x_range,
+            output_backend=output_backend,
         )
 
         if window_size:
             if isinstance(percentiles, int):
                 percentiles = (percentiles,)
+            # Ensure percentiles are sorted so that colors make sense.
+            percentiles = tuple(sorted(percentiles))
 
         # add an empty dimension to ihs array if 1D
         ihs = np.reshape(ihs, (ihs.shape[0], -1))
-        bokeh_palette = bokeh.palettes.all_palettes[palette]
+
+        # select the base color palette to work from
+        base_palette = bokeh.palettes.all_palettes[palette][8]
+
+        # keep only enough colours to plot the IHS tracks
+        bokeh_palette = base_palette[: ihs.shape[1]]
+
+        # reverse the colors so darkest is last
+        bokeh_palette = bokeh_palette[::-1]
+
+        # plot IHS tracks
         for i in range(ihs.shape[1]):
             ihs_perc = ihs[:, i]
-            if ihs.shape[1] >= 3:
-                color = bokeh_palette[ihs.shape[1]][i]
-            elif ihs.shape[1] == 2:
-                color = bokeh_palette[3][i]
-            else:
-                color = None
+            color = bokeh_palette[i]
 
             # plot ihs
             fig.circle(
                 x=x,
                 y=ihs_perc,
-                size=3,
-                line_width=0.15,
-                line_color="black",
+                size=4,
+                line_width=0,
+                line_color=color,
                 fill_color=color,
             )
 
@@ -4395,6 +4435,7 @@ class AnophelesDataResource(
         track_height: gplt_params.track_height = 170,
         genes_height: gplt_params.genes_height = gplt_params.genes_height_default,
         show: gplt_params.show = True,
+        output_backend: gplt_params.output_backend = gplt_params.output_backend_default,
     ) -> gplt_params.figure:
         # gwss track
         fig1 = self.plot_ihs_gwss_track(
@@ -4424,6 +4465,7 @@ class AnophelesDataResource(
             width=width,
             height=track_height,
             show=False,
+            output_backend=output_backend,
         )
 
         fig1.xaxis.visible = False
@@ -4436,6 +4478,7 @@ class AnophelesDataResource(
             height=genes_height,
             x_range=fig1.x_range,
             show=False,
+            output_backend=output_backend,
         )
 
         # combine plots into a single figure
@@ -4600,6 +4643,7 @@ class AnophelesDataResource(
         height: gplt_params.height = 200,
         show: gplt_params.show = True,
         x_range: Optional[gplt_params.x_range] = None,
+        output_backend: gplt_params.output_backend = gplt_params.output_backend_default,
     ) -> gplt_params.figure:
         # compute G123
         x, g123 = self.g123_gwss(
@@ -4637,6 +4681,7 @@ class AnophelesDataResource(
             toolbar_location="above",
             x_range=x_range,
             y_range=(0, 1),
+            output_backend=output_backend,
         )
 
         # plot G123
@@ -4644,7 +4689,7 @@ class AnophelesDataResource(
             x=x,
             y=g123,
             size=3,
-            line_width=0.5,
+            line_width=1,
             line_color="black",
             fill_color=None,
         )
@@ -4685,6 +4730,7 @@ class AnophelesDataResource(
         track_height: gplt_params.track_height = 170,
         genes_height: gplt_params.genes_height = gplt_params.genes_height_default,
         show: gplt_params.show = True,
+        output_backend: gplt_params.output_backend = gplt_params.output_backend_default,
     ) -> gplt_params.figure:
         # gwss track
         fig1 = self.plot_g123_gwss_track(
@@ -4702,6 +4748,7 @@ class AnophelesDataResource(
             width=width,
             height=track_height,
             show=False,
+            output_backend=output_backend,
         )
 
         fig1.xaxis.visible = False
@@ -4714,6 +4761,7 @@ class AnophelesDataResource(
             height=genes_height,
             x_range=fig1.x_range,
             show=False,
+            output_backend=output_backend,
         )
 
         # combine plots into a single figure

--- a/notebooks/plot_cnv.ipynb
+++ b/notebooks/plot_cnv.ipynb
@@ -25,7 +25,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "74c46a04",
    "metadata": {},
@@ -118,7 +117,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a302d86c",
    "metadata": {},

--- a/notebooks/plot_h12_h1x.ipynb
+++ b/notebooks/plot_h12_h1x.ipynb
@@ -21,7 +21,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a67ec21b",
    "metadata": {},
@@ -99,6 +98,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cd125828",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_h12_gwss(\n",
+    "    contig=contig,\n",
+    "    analysis=\"gamb_colu\",\n",
+    "    window_size=2000,\n",
+    "    sample_query=coh1_query,\n",
+    "    cohort_size=20,\n",
+    "    output_backend=\"canvas\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "5716e777",
    "metadata": {},
    "outputs": [],
@@ -130,7 +146,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "2801861c",
    "metadata": {},
@@ -234,11 +249,19 @@
     "    cohort_size=20,\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67e3bfcc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.9 ('malariagen-data-ea_k69mu-py3.8')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/notebooks/plot_ihs_gwss.ipynb
+++ b/notebooks/plot_ihs_gwss.ipynb
@@ -122,7 +122,7 @@
    "source": [
     "af1.plot_ihs_gwss(\n",
     "    contig=\"X\",\n",
-    "    window_size=20_000,\n",
+    "    window_size=2_000,\n",
     "    sample_query=\"cohort_admin1_year == 'KE-03_fune_2016'\",\n",
     "    max_cohort_size=20,\n",
     ")"
@@ -137,11 +137,19 @@
    "source": [
     "af1.plot_ihs_gwss(\n",
     "    contig=\"X\",\n",
-    "    window_size=2000,\n",
+    "    window_size=200,\n",
     "    sample_query=\"cohort_admin1_year == 'KE-03_fune_2016'\",\n",
     "    max_cohort_size=None,\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "110b81e5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
An issue we are experiencing in the selection atlas project is that multiple GWSS plots can cause problems in the browser, like long page load times and unresponsiveness (xref https://github.com/anopheles-genomic-surveillance/selection-atlas/issues/51).

Here we switch all bokeh genome plots to use "webgl" instead of the default "canvas" for the `output_backend` parameter. Webgl in general renders plots faster and can handle plots with more points than canvas. See the [bokeh docs on webgl acceleration](https://docs.bokeh.org/en/latest/docs/user_guide/output/webgl.html#webgl-acceleration) for more info.

In addition to faster and more responsive plots, this also removes the downsampling of glyphs that otherwise happens with the canvas backend when zooming in or out, which is nice.

Because the webgl plots have a very slightly different visual appearance, this PR also includes some tweaks to the visual style of plots to make things clearer and more uniform between backends. In particular, it seems that glyphs can appear a little blurry with webgl if the `line_width` parameter is a fractional value, so we set it to 0 or 1 here throughout.

There are also a couple of tweaks to the genes track and RoH track plots to make them more compact.