### PR TITLE
Update cohorts version & expected frq col

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: gcs_cache
-          key: gcs_cache_tests_20230811
+          key: gcs_cache_notebooks_20230811
 
       - name: Run notebooks
         run: poetry run jupyter nbconvert --execute notebooks/* --inplace
@@ -41,4 +41,4 @@ jobs:
         if: always()
         with:
           path: gcs_cache
-          key: gcs_cache_tests_20230811
+          key: gcs_cache_notebooks_20230811

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -1,44 +1,44 @@
 name: notebooks
 on:
-    push:
-        branches:
-            - master
-    pull_request:
-        branches:
-            - master
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
-    notebooks:
-        strategy:
-            fail-fast: true
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout source
-              uses: actions/checkout@v3
+  notebooks:
+    strategy:
+      fail-fast: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
 
-            - name: Install poetry
-              run: pipx install poetry==1.4.2
+      - name: Install poetry
+        run: pipx install poetry==1.4.2
 
-            - name: Setup python
-              uses: actions/setup-python@v4
-              with:
-                  python-version: '3.11'
-                  cache: 'poetry'
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: "poetry"
 
-            - name: Install dependencies
-              run: poetry install
+      - name: Install dependencies
+        run: poetry install
 
-            - name: Restore GCS cache
-              uses: actions/cache/restore@v3
-              with:
-                  path: gcs_cache
-                  key: gcs_cache_notebooks_20230425
+      - name: Restore GCS cache
+        uses: actions/cache/restore@v3
+        with:
+          path: gcs_cache
+          key: gcs_cache_tests_20230811
 
-            - name: Run notebooks
-              run: poetry run jupyter nbconvert --execute notebooks/* --inplace
+      - name: Run notebooks
+        run: poetry run jupyter nbconvert --execute notebooks/* --inplace
 
-            - name: Save GCS cache
-              uses: actions/cache/save@v3
-              if: always()
-              with:
-                  path: gcs_cache
-                  key: gcs_cache_notebooks_20230425
+      - name: Save GCS cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: gcs_cache
+          key: gcs_cache_tests_20230811

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,51 +1,51 @@
 name: tests
 on:
-    push:
-        branches:
-            - master
-    pull_request:
-        branches:
-            - master
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
-    tests:
-        strategy:
-            fail-fast: true
-            matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11']
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout source
-              uses: actions/checkout@v3
+  tests:
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
 
-            - name: Install poetry
-              run: pipx install poetry==1.4.2
+      - name: Install poetry
+        run: pipx install poetry==1.4.2
 
-            - name: Setup python
-              uses: actions/setup-python@v4
-              with:
-                  python-version: ${{ matrix.python-version }}
-                  cache: 'poetry'
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "poetry"
 
-            - name: Install dependencies
-              run: poetry install
+      - name: Install dependencies
+        run: poetry install
 
-            # Run a subset of tests first which run quickly without accessing
-            # any remote data in order to fail fast where possible.
-            - name: Run fast unit tests
-              run: poetry run pytest -v tests/anoph --typeguard-packages=malariagen_data,malariagen_data.anoph
+      # Run a subset of tests first which run quickly without accessing
+      # any remote data in order to fail fast where possible.
+      - name: Run fast unit tests
+        run: poetry run pytest -v tests/anoph --typeguard-packages=malariagen_data,malariagen_data.anoph
 
-            - name: Restore GCS cache
-              uses: actions/cache/restore@v3
-              with:
-                  path: gcs_cache
-                  key: gcs_cache_tests_20230420
+      - name: Restore GCS cache
+        uses: actions/cache/restore@v3
+        with:
+          path: gcs_cache
+          key: gcs_cache_tests_20230811
 
-            - name: Run full test suite
-              run: poetry run pytest -v tests
+      - name: Run full test suite
+        run: poetry run pytest -v tests
 
-            - name: Save GCS cache
-              uses: actions/cache/save@v3
-              if: always()
-              with:
-                  path: gcs_cache
-                  key: gcs_cache_tests_20230420
+      - name: Save GCS cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: gcs_cache
+          key: gcs_cache_tests_20230811

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -387,7 +387,7 @@ def test_snp_effects():
 
 
 def test_snp_allele_frequencies__dict_cohorts():
-    ag3 = setup_ag3(cohorts_analysis="20211101")
+    ag3 = setup_ag3(cohorts_analysis="20230516")
     cohorts = {
         "ke": "country == 'Kenya'",
         "bf_2012_col": "country == 'Burkina Faso' and year == 2012 and aim_species == 'coluzzii'",
@@ -437,7 +437,7 @@ def test_snp_allele_frequencies__dict_cohorts():
 
 
 def test_snp_allele_frequencies__str_cohorts__effects():
-    ag3 = setup_ag3(cohorts_analysis="20211101")
+    ag3 = setup_ag3(cohorts_analysis="20230516")
     cohorts = "admin1_month"
     min_cohort_size = 10
     universal_fields = [
@@ -473,7 +473,7 @@ def test_snp_allele_frequencies__str_cohorts__effects():
     expected_fields = universal_fields + frq_cohort_labels + ["max_af"] + effects_fields
 
     assert isinstance(df, pd.DataFrame)
-    assert len(df) == 16526
+    assert len(df) == 16641
     assert sorted(df.columns.tolist()) == sorted(expected_fields)
     assert df.index.names == [
         "contig",
@@ -485,7 +485,7 @@ def test_snp_allele_frequencies__str_cohorts__effects():
 
 
 def test_snp_allele_frequencies__query():
-    ag3 = setup_ag3(cohorts_analysis="20211101")
+    ag3 = setup_ag3(cohorts_analysis="20230516")
     cohorts = "admin1_year"
     min_cohort_size = 10
     expected_columns = [
@@ -668,7 +668,7 @@ def _check_frequency(x):
     ],
 )
 def test_gene_cnv_frequencies(region, cohorts):
-    ag3 = setup_ag3(cohorts_analysis="20211101")
+    ag3 = setup_ag3(cohorts_analysis="20230516")
 
     universal_fields = [
         "contig",
@@ -719,7 +719,7 @@ def test_gene_cnv_frequencies(region, cohorts):
 
 
 def test_gene_cnv_frequencies__query():
-    ag3 = setup_ag3(cohorts_analysis="20211101")
+    ag3 = setup_ag3(cohorts_analysis="20230516")
 
     region = "3L"
 
@@ -751,7 +751,7 @@ def test_gene_cnv_frequencies__query():
 
 
 def test_gene_cnv_frequencies__max_coverage_variance():
-    ag3 = setup_ag3(cohorts_analysis="20211101")
+    ag3 = setup_ag3(cohorts_analysis="20230516")
     region = "3L"
     df_genes = ag3.genome_features(region=region).query("type == 'gene'")
 
@@ -776,7 +776,7 @@ def test_gene_cnv_frequencies__max_coverage_variance():
         drop_invariant=False,
     )
     expected_frq_columns = [
-        "frq_GM-L_gcx2_2012",
+        "frq_GM-L_gcx2_2006",
         "frq_GM-M_gcx2_2012",
         "frq_GM-N_gcx1_2011",
     ]
@@ -807,7 +807,7 @@ def test_gene_cnv_frequencies__max_coverage_variance():
 
 
 def test_gene_cnv_frequencies__drop_invariant():
-    ag3 = setup_ag3(cohorts_analysis="20211101")
+    ag3 = setup_ag3(cohorts_analysis="20230516")
     region = "3L"
 
     expected_columns = [
@@ -839,7 +839,7 @@ def test_gene_cnv_frequencies__drop_invariant():
 
 
 def test_gene_cnv_frequencies__dup_samples():
-    ag3 = setup_ag3(cohorts_analysis="20211101")
+    ag3 = setup_ag3(cohorts_analysis="20230516")
     df_dup = ag3.gene_cnv_frequencies(
         region="3L",
         cohorts="admin1_year",
@@ -856,7 +856,7 @@ def test_gene_cnv_frequencies__dup_samples():
 def test_gene_cnv_frequencies__multi_contig_x():
     # https://github.com/malariagen/malariagen-data-python/issues/166
 
-    ag3 = setup_ag3(cohorts_analysis="20211101")
+    ag3 = setup_ag3(cohorts_analysis="20230516")
 
     df1 = ag3.gene_cnv_frequencies(
         region="X",
@@ -882,7 +882,7 @@ def test_gene_cnv_frequencies__multi_contig_x():
 def test_gene_cnv_frequencies__missing_samples():
     # https://github.com/malariagen/malariagen-data-python/issues/183
 
-    ag3 = setup_ag3(cohorts_analysis="20211101", pre=True)
+    ag3 = setup_ag3(cohorts_analysis="20230516", pre=True)
 
     df = ag3.gene_cnv_frequencies(
         region="3L",
@@ -944,7 +944,7 @@ def test_locate_region(region_raw):
 
 
 def test_aa_allele_frequencies():
-    ag3 = setup_ag3(cohorts_analysis="20211101")
+    ag3 = setup_ag3(cohorts_analysis="20230516")
 
     expected_fields = [
         "transcript",
@@ -991,7 +991,7 @@ def _check_snp_allele_frequencies_advanced(
     nobs_mode="called",
     variant_query="max_af > 0.02",
 ):
-    ag3 = setup_ag3(cohorts_analysis="20211101")
+    ag3 = setup_ag3(cohorts_analysis="20230516")
 
     ds = ag3.snp_allele_frequencies_advanced(
         transcript=transcript,
@@ -1147,7 +1147,7 @@ def _check_aa_allele_frequencies_advanced(
     nobs_mode="called",
     variant_query="max_af > 0.02",
 ):
-    ag3 = setup_ag3(cohorts_analysis="20211101")
+    ag3 = setup_ag3(cohorts_analysis="20230516")
 
     ds = ag3.aa_allele_frequencies_advanced(
         transcript=transcript,
@@ -1399,7 +1399,7 @@ def _check_gene_cnv_frequencies_advanced(
     drop_invariant=True,
     max_coverage_variance=0.2,
 ):
-    ag3 = setup_ag3(cohorts_analysis="20211101")
+    ag3 = setup_ag3(cohorts_analysis="20230516")
 
     ds = ag3.gene_cnv_frequencies_advanced(
         region=region,
@@ -1631,7 +1631,7 @@ def test_gene_cnv_frequencies_advanced__max_coverage_variance(max_coverage_varia
 def test_gene_cnv_frequencies_advanced__multi_contig_x():
     # https://github.com/malariagen/malariagen-data-python/issues/166
 
-    ag3 = setup_ag3(cohorts_analysis="20211101")
+    ag3 = setup_ag3(cohorts_analysis="20230516")
 
     ds1 = ag3.gene_cnv_frequencies_advanced(
         region="X",
@@ -1668,7 +1668,7 @@ def test_gene_cnv_frequencies_advanced__multi_contig_x():
 def test_gene_cnv_frequencies_advanced__missing_samples():
     # https://github.com/malariagen/malariagen-data-python/issues/183
 
-    ag3 = setup_ag3(cohorts_analysis="20211101", pre=True)
+    ag3 = setup_ag3(cohorts_analysis="20230516", pre=True)
 
     ds = ag3.gene_cnv_frequencies_advanced(
         region="3L",
@@ -1680,7 +1680,7 @@ def test_gene_cnv_frequencies_advanced__missing_samples():
 
 
 def test_gene_cnv_frequencies_advanced__dup_samples():
-    ag3 = setup_ag3(cohorts_analysis="20211101")
+    ag3 = setup_ag3(cohorts_analysis="20230516")
     ds_dup = ag3.gene_cnv_frequencies_advanced(
         region="3L",
         area_by="admin1_iso",


### PR DESCRIPTION
* Resolves #417 

To solve the assertion errors, I had to update to the latest cohort version to ensure the cohort names match (i.e. accounting for the single mismatch due to the year change) & update the hard-coded expected_frq_columns on `test_gene_cnv_frequencies__max_coverage_variance()`. 

After this, we also need to update the expected number of positions returned from `test_snp_allele_frequencies__str_cohorts__effects()`, as the number of rows in the AF df is higher than the expected one. This is due to the change in cohorts versions.

Not sure whether there was a reason for using the `20211101` version here (e.g. is this a fixed cohorts release for 3.0?) but it seems like a good chance to update the cohorts version for these tests, given that we have `20230516` as the default in the package. 

Alternatively, if we want to keep the older version instead, it would be a case of manually changing the cohorts file for the GM-B sample set so the column values will properly match.