### PR TITLE
Fix test for sample sets with no phasing data

### DIFF
--- a/tests/anoph/test_hap_data.py
+++ b/tests/anoph/test_hap_data.py
@@ -168,6 +168,7 @@ def check_haplotypes(
         ]
     )
     n_samples_phased = len(samples_phased)
+
     # Check if no samples phased in the analysis.
     if n_samples_phased == 0:
         with pytest.raises(ValueError):

--- a/tests/anoph/test_hap_data.py
+++ b/tests/anoph/test_hap_data.py
@@ -168,7 +168,6 @@ def check_haplotypes(
         ]
     )
     n_samples_phased = len(samples_phased)
-
     # Check if no samples phased in the analysis.
     if n_samples_phased == 0:
         with pytest.raises(ValueError):
@@ -504,16 +503,15 @@ def test_haplotypes_with_empty_calls(ag3_sim_fixture, ag3_sim_api: AnophelesHapD
     fixture = ag3_sim_fixture
 
     # Fix a sample set that will be empty for the fixed (arab) analysis calls
-    sample_set = "tennessen-2021"
+    sample_set = "AG1000G-AO"
     region = fixture.random_region_str()
     analysis = "arab"
 
-    with pytest.raises(ValueError):
-        check_haplotypes(
-            fixture=fixture,
-            api=api,
-            sample_sets=sample_set,
-            region=region,
-            analysis=analysis,
-            sample_query=None,
-        )
+    check_haplotypes(
+        fixture=fixture,
+        api=api,
+        sample_sets=sample_set,
+        region=region,
+        analysis=analysis,
+        sample_query=None,
+    )


### PR DESCRIPTION
* Resolves #432

The previous fix on https://github.com/malariagen/malariagen-data-python/pull/433 was using a sample set not used in the fixtures. 

Here, corrected the sample set used, and deleted the assertion to avoid redundancy as the code is the same as in `check_haplotypes()`.