### PR TITLE
Pass through render_mode when plotting a dendrogram

### DIFF
--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -6524,6 +6524,7 @@ class AnophelesDataResource(
             color_threshold=0,
             count_sort=count_sort,
             distance_sort=distance_sort,
+            render_mode=render_mode,
         )
 
         # Configure hover data.

--- a/malariagen_data/plotly_dendrogram.py
+++ b/malariagen_data/plotly_dendrogram.py
@@ -112,7 +112,7 @@ class _Dendrogram(object):
         color_threshold=None,
         count_sort=True,
         distance_sort=True,
-        render_mode="svg",
+        render_mode="auto",
     ):
         self.orientation = orientation
         self.labels = labels

--- a/notebooks/plot_haplotype_clustering.ipynb
+++ b/notebooks/plot_haplotype_clustering.ipynb
@@ -83,6 +83,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c0420334-124d-4bab-9ef7-bb9ceb99d6f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_haplotype_clustering(\n",
+    "    region=\"2L:2,410,000-2,430,000\",\n",
+    "    sample_sets=[\"AG1000G-GH\", \"AG1000G-BF-B\"],\n",
+    "    analysis=\"gamb_colu\",\n",
+    "    color=\"taxon\",\n",
+    "    symbol=\"country\",\n",
+    "    linkage_method=\"single\",\n",
+    "    width=1000,\n",
+    "    height=500,\n",
+    "    count_sort=True,\n",
+    "    distance_sort=False,\n",
+    "    render_mode=\"svg\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "e957de19-af70-412a-8c75-2e6835ffb2cd",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
This PR fixes an omission where the `render_mode` parameter is not fully passed through to plotting code. Follow up to #450.