### PR TITLE
Improve performance of dendrogram plotting and saving results to the cache

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -193,16 +193,20 @@ class Ag3(AnophelesDataResource):
 
         if plot_kwargs is None:
             plot_kwargs = dict()
-        taxon_palette = px.colors.qualitative.Plotly
+        taxon_palette = px.colors.qualitative.Vivid
         taxon_color_map = {
-            "gambiae": taxon_palette[0],
-            "coluzzii": taxon_palette[1],
+            "gambiae": taxon_palette[1],
+            "coluzzii": taxon_palette[0],
             "arabiensis": taxon_palette[2],
-            "gcx1": taxon_palette[3],
-            "gcx2": taxon_palette[4],
-            "gcx3": taxon_palette[5],
-            "intermediate_gambiae_coluzzii": taxon_palette[6],
-            "intermediate_arabiensis_gambiae": taxon_palette[7],
+            "merus": taxon_palette[3],
+            "melas": taxon_palette[4],
+            "quadriannulatus": taxon_palette[5],
+            "fontenillei": taxon_palette[6],
+            "gcx1": taxon_palette[7],
+            "gcx2": taxon_palette[8],
+            "gcx3": taxon_palette[9],
+            "gcx4": taxon_palette[10],
+            "unassigned": "black",
         }
         plot_kwargs.setdefault("color_discrete_map", taxon_color_map)
         plot_kwargs.setdefault(

--- a/malariagen_data/anoph/base.py
+++ b/malariagen_data/anoph/base.py
@@ -17,6 +17,7 @@ from typing import (
 import bokeh.io
 import numpy as np
 import pandas as pd
+import zarr
 from numpydoc_decorator import doc
 from tqdm.auto import tqdm
 from tqdm.dask import TqdmCallback
@@ -408,13 +409,18 @@ class AnophelesBase:
         self._results_cache_add_analysis_params(params)
         cache_key, _ = hash_params(params)
         cache_path = self._results_cache / name / cache_key
-        results_path = cache_path / "results.npz"
-        if not results_path.exists():
-            raise CacheMiss
-        with self._spinner("Load results from cache"):
-            results = np.load(results_path)
-        # TODO Do we need to read the arrays and then close the npz file?
-        return results
+
+        # Read zipped zarr format.
+        results_path = cache_path / "results.zarr.zip"
+        if results_path.exists():
+            return zarr.load(results_path)
+
+        # For backwards compatibility, read npz format.
+        legacy_results_path = cache_path / "results.npz"
+        if legacy_results_path.exists():
+            return np.load(legacy_results_path)
+
+        raise CacheMiss
 
     @check_types
     def results_cache_set(
@@ -423,14 +429,23 @@ class AnophelesBase:
         name = type(self).__name__.lower() + "_" + name
         if self._results_cache is None:
             return
+
+        # Set up parameters for the results to be saved.
         params = params.copy()
         self._results_cache_add_analysis_params(params)
         cache_key, params_json = hash_params(params)
+
+        # Determine storage path.
         cache_path = self._results_cache / name / cache_key
         cache_path.mkdir(exist_ok=True, parents=True)
+
+        # Write the parameters as a JSON file.
         params_path = cache_path / "params.json"
-        results_path = cache_path / "results.npz"
+
+        # Write the data to be cached as a zipped zarr file.
+        results_path = cache_path / "results.zarr.zip"
+
         with self._spinner("Save results to cache"):
             with params_path.open(mode="w") as f:
                 f.write(params_json)
-            np.savez_compressed(results_path, **results)
+            zarr.save(results_path, **results)

--- a/malariagen_data/anoph/base.py
+++ b/malariagen_data/anoph/base.py
@@ -411,7 +411,8 @@ class AnophelesBase:
         results_path = cache_path / "results.npz"
         if not results_path.exists():
             raise CacheMiss
-        results = np.load(results_path)
+        with self._spinner("Load results from cache"):
+            results = np.load(results_path)
         # TODO Do we need to read the arrays and then close the npz file?
         return results
 
@@ -429,6 +430,7 @@ class AnophelesBase:
         cache_path.mkdir(exist_ok=True, parents=True)
         params_path = cache_path / "params.json"
         results_path = cache_path / "results.npz"
-        with params_path.open(mode="w") as f:
-            f.write(params_json)
-        np.savez_compressed(results_path, **results)
+        with self._spinner("Save results to cache"):
+            with params_path.open(mode="w") as f:
+                f.write(params_json)
+            np.savez_compressed(results_path, **results)

--- a/malariagen_data/anoph/base.py
+++ b/malariagen_data/anoph/base.py
@@ -417,7 +417,7 @@ class AnophelesBase:
 
         # For backwards compatibility, read npz format.
         legacy_results_path = cache_path / "results.npz"
-        if legacy_results_path.exists():
+        if legacy_results_path.exists():  # pragma: no cover
             return np.load(legacy_results_path)
 
         raise CacheMiss

--- a/malariagen_data/plotly_dendrogram.py
+++ b/malariagen_data/plotly_dendrogram.py
@@ -1,398 +1,123 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
-from collections import OrderedDict
-
 import numpy as np
-import scipy as scp
+import pandas as pd
+import plotly.express as px
 import scipy.cluster.hierarchy as sch
-from plotly.graph_objs import graph_objs
 
 
-def create_dendrogram(
+def plot_dendrogram(
     dist,
-    orientation="bottom",
-    labels=None,
-    colorscale=None,
-    linkagefun=lambda x: sch.linkage(x, "complete"),
-    hovertext=None,
-    color_threshold=None,
-    count_sort=True,
-    distance_sort=False,
-    render_mode="auto",
+    linkage_method,
+    count_sort,
+    distance_sort,
+    render_mode,
+    width,
+    height,
+    title,
+    line_props,
+    leaf_data,
+    leaf_hover_name,
+    leaf_hover_data,
+    leaf_color,
+    leaf_symbol,
+    leaf_scatter_kwargs,
+    leaf_y=0,
+    template="simple_white",
 ):
-    """
-    Function that returns a dendrogram Plotly figure object. This is a thin
-    wrapper around scipy.cluster.hierarchy.dendrogram.
+    # Hierarchical clustering.
+    Z = sch.linkage(dist, method=linkage_method)
 
-    See also https://dash.plot.ly/dash-bio/clustergram.
-
-    :param (ndarray) dist: Distance matrix in condensed form.
-    :param (str) orientation: 'top', 'right', 'bottom', or 'left'
-    :param (list) labels: List of axis category labels(observation labels)
-    :param (list) colorscale: Optional colorscale for the dendrogram tree.
-                              Requires 8 colors to be specified, the 7th of
-                              which is ignored.  With scipy>=1.5.0, the 2nd, 3rd
-                              and 6th are used twice as often as the others.
-                              Given a shorter list, the missing values are
-                              replaced with defaults and with a longer list the
-                              extra values are ignored.
-    :param (function) linkagefun: Function to compute the linkage matrix from
-                               the pairwise distances
-    :param (list[list]) hovertext: List of hovertext for constituent traces of dendrogram
-                               clusters
-    :param (double) color_threshold: Value at which the separation of clusters will be made
-
-    Example 1: Simple bottom oriented dendrogram
-
-    >>> from plotly.figure_factory import create_dendrogram
-
-    >>> import numpy as np
-
-    >>> X = np.random.rand(10, 10)
-    >>> fig = create_dendrogram(X)
-    >>> fig.show()
-
-    Example 2: Dendrogram to put on the left of the heatmap
-
-    >>> from plotly.figure_factory import create_dendrogram
-
-    >>> import numpy as np
-
-    >>> X = np.random.rand(5, 5)
-    >>> names = ["Jack", "Oxana", "John", "Chelsea", "Mark"]
-    >>> dendro = create_dendrogram(X, orientation="right", labels=names)
-    >>> dendro.update_layout({"width": 700, "height": 500})  # doctest: +SKIP
-    >>> dendro.show()
-
-    Example 3: Dendrogram with Pandas
-
-    >>> from plotly.figure_factory import create_dendrogram
-
-    >>> import numpy as np
-    >>> import pandas as pd
-
-    >>> Index = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
-    >>> df = pd.DataFrame(abs(np.random.randn(10, 10)), index=Index)
-    >>> fig = create_dendrogram(df, labels=Index)
-    >>> fig.show()
-    """
-
-    dendrogram = _Dendrogram(
-        dist,
-        orientation,
-        labels,
-        colorscale,
-        linkagefun=linkagefun,
-        hovertext=hovertext,
-        color_threshold=color_threshold,
+    # Compute the dendrogram but don't plot it.
+    dend = sch.dendrogram(
+        Z,
         count_sort=count_sort,
         distance_sort=distance_sort,
-        render_mode=render_mode,
+        no_plot=True,
     )
 
-    return graph_objs.Figure(data=dendrogram.data, layout=dendrogram.layout)
+    # Compile the line coordinates into a single dataframe.
+    icoord = dend["icoord"]
+    dcoord = dend["dcoord"]
+    line_segments_x = []
+    line_segments_y = []
+    for ik, dk in zip(icoord, dcoord):
+        # Adding None here breaks up the lines.
+        line_segments_x += ik + [None]
+        line_segments_y += dk + [None]
+    df_line_segments = pd.DataFrame({"x": line_segments_x, "y": line_segments_y})
 
+    # Convert X coordinates to haplotype indices (scipy multiplies coordinates by 10).
+    df_line_segments["x"] = (df_line_segments["x"] - 5) / 10
 
-class _Dendrogram(object):
-    """Refer to FigureFactory.create_dendrogram() for docstring."""
+    # Plot the lines.
+    fig = px.line(
+        df_line_segments,
+        x="x",
+        y="y",
+        render_mode=render_mode,
+        template=template,
+    )
 
-    def __init__(
-        self,
-        dist,
-        orientation="bottom",
-        labels=None,
-        colorscale=None,
-        width=np.inf,
-        height=np.inf,
-        xaxis="xaxis",
-        yaxis="yaxis",
-        linkagefun=lambda x: sch.linkage(x, "complete"),
-        hovertext=None,
-        color_threshold=None,
-        count_sort=True,
-        distance_sort=True,
-        render_mode="auto",
-    ):
-        self.orientation = orientation
-        self.labels = labels
-        self.xaxis = xaxis
-        self.yaxis = yaxis
-        self.data = []
-        self.leaves = []
-        self.sign = {self.xaxis: 1, self.yaxis: 1}
-        self.layout = {self.xaxis: {}, self.yaxis: {}}
+    # Style the lines.
+    if line_props is None:
+        line_props = dict()
+    line_props.setdefault("width", 0.5)
+    line_props.setdefault("color", "black")
+    fig.update_traces(line=line_props)
 
-        if self.orientation in ["left", "bottom"]:
-            self.sign[self.xaxis] = 1
-        else:
-            self.sign[self.xaxis] = -1
+    # Reorder leaf data to align with dendrogram.
+    leaves = dend["leaves"]
+    n_leaves = len(leaves)
+    leaf_data = leaf_data.iloc[leaves]
 
-        if self.orientation in ["right", "bottom"]:
-            self.sign[self.yaxis] = 1
-        else:
-            self.sign[self.yaxis] = -1
-
-        (dd_traces, xvals, yvals, ordered_labels, leaves) = self.get_dendrogram_traces(
-            dist=dist,
-            colorscale=colorscale,
-            linkagefun=linkagefun,
-            hovertext=hovertext,
-            color_threshold=color_threshold,
-            count_sort=count_sort,
-            distance_sort=distance_sort,
-            render_mode=render_mode,
+    # Add scatter plot to draw the leaves.
+    fig.add_traces(
+        list(
+            px.scatter(
+                data_frame=leaf_data,
+                x=np.arange(n_leaves),
+                y=np.repeat(leaf_y, n_leaves),
+                color=leaf_color,
+                symbol=leaf_symbol,
+                render_mode=render_mode,
+                hover_name=leaf_hover_name,
+                hover_data=leaf_hover_data,
+                template=template,
+                **leaf_scatter_kwargs,
+            ).select_traces()
         )
+    )
 
-        self.labels = ordered_labels
-        self.leaves = leaves
-        yvals_flat = yvals.flatten()
-        xvals_flat = xvals.flatten()
+    # Style the figure.
+    fig.update_layout(
+        width=width,
+        height=height,
+        title=title,
+        autosize=True,
+        hovermode="closest",
+        # I cannot get the xaxis title to appear below the plot, and when
+        # it's above the plot it often overlaps the title, so hiding it
+        # for now.
+        xaxis_title=None,
+        yaxis_title="Distance (no. SNPs)",
+        showlegend=True,
+    )
 
-        self.zero_vals = []
+    # Style axes.
+    fig.update_xaxes(
+        mirror=False,
+        showgrid=False,
+        showline=False,
+        showticklabels=False,
+        ticks="",
+        range=(-2, n_leaves + 2),
+    )
+    fig.update_yaxes(
+        mirror=False,
+        showgrid=False,
+        showline=False,
+        showticklabels=True,
+        ticks="outside",
+        range=(leaf_y - 1, np.max(dcoord) + 1),
+    )
 
-        for i in range(len(yvals_flat)):
-            if yvals_flat[i] == 0.0 and xvals_flat[i] not in self.zero_vals:
-                self.zero_vals.append(xvals_flat[i])
-
-        if len(self.zero_vals) > len(yvals) + 1:
-            # If the length of zero_vals is larger than the length of yvals,
-            # it means that there are wrong vals because of the identicial samples.
-            # Three and more identicial samples will make the yvals of spliting
-            # center into 0 and it will accidentally take it as leaves.
-            l_border = int(min(self.zero_vals))
-            r_border = int(max(self.zero_vals))
-            correct_leaves_pos = range(
-                l_border, r_border + 1, int((r_border - l_border) / len(yvals))
-            )
-            # Regenerating the leaves pos from the self.zero_vals with equally intervals.
-            self.zero_vals = [v for v in correct_leaves_pos]
-
-        self.zero_vals.sort()
-        self.layout = self.set_figure_layout(width, height)
-        self.data = dd_traces
-
-    def get_color_dict(self, colorscale):
-        """
-        Returns colorscale used for dendrogram tree clusters.
-
-        :param (list) colorscale: Colors to use for the plot in rgb format.
-        :rtype (dict): A dict of default colors mapped to the user colorscale.
-
-        """
-
-        # These are the color codes returned for dendrograms
-        # We're replacing them with nicer colors
-        # This list is the colors that can be used by dendrogram, which were
-        # determined as the combination of the default above_threshold_color and
-        # the default color palette (see scipy/cluster/hierarchy.py)
-        d = {
-            "r": "red",
-            "g": "green",
-            "b": "blue",
-            "c": "cyan",
-            "m": "magenta",
-            "y": "yellow",
-            "k": "black",
-            # TODO: 'w' doesn't seem to be in the default color
-            # palette in scipy/cluster/hierarchy.py
-            "w": "white",
-        }
-        default_colors = OrderedDict(sorted(d.items(), key=lambda t: t[0]))
-
-        if colorscale is None:
-            rgb_colorscale = [
-                "rgb(0,116,217)",  # blue
-                "rgb(35,205,205)",  # cyan
-                "rgb(61,153,112)",  # green
-                "rgb(40,35,35)",  # black
-                "rgb(133,20,75)",  # magenta
-                "rgb(255,65,54)",  # red
-                "rgb(255,255,255)",  # white
-                "rgb(255,220,0)",  # yellow
-            ]
-        else:
-            rgb_colorscale = colorscale
-
-        for i in range(len(default_colors.keys())):
-            k = list(default_colors.keys())[i]  # PY3 won't index keys
-            if i < len(rgb_colorscale):
-                default_colors[k] = rgb_colorscale[i]
-
-        # add support for cyclic format colors as introduced in scipy===1.5.0
-        # before this, the colors were named 'r', 'b', 'y' etc., now they are
-        # named 'C0', 'C1', etc. To keep the colors consistent regardless of the
-        # scipy version, we try as much as possible to map the new colors to the
-        # old colors
-        # this mapping was found by inpecting scipy/cluster/hierarchy.py (see
-        # comment above).
-        new_old_color_map = [
-            ("C0", "b"),
-            ("C1", "g"),
-            ("C2", "r"),
-            ("C3", "c"),
-            ("C4", "m"),
-            ("C5", "y"),
-            ("C6", "k"),
-            ("C7", "g"),
-            ("C8", "r"),
-            ("C9", "c"),
-        ]
-        for nc, oc in new_old_color_map:
-            try:
-                default_colors[nc] = default_colors[oc]
-            except KeyError:
-                # it could happen that the old color isn't found (if a custom
-                # colorscale was specified), in this case we set it to an
-                # arbitrary default.
-                default_colors[nc] = "rgb(0,116,217)"
-
-        return default_colors
-
-    def set_axis_layout(self, axis_key):
-        """
-        Sets and returns default axis object for dendrogram figure.
-
-        :param (str) axis_key: E.g., 'xaxis', 'xaxis1', 'yaxis', yaxis1', etc.
-        :rtype (dict): An axis_key dictionary with set parameters.
-
-        """
-        axis_defaults = {
-            "type": "linear",
-            "ticks": "outside",
-            "mirror": "allticks",
-            "rangemode": "tozero",
-            "showticklabels": True,
-            "zeroline": False,
-            "showgrid": False,
-            "showline": True,
-        }
-
-        if len(self.labels) != 0:
-            axis_key_labels = self.xaxis
-            if self.orientation in ["left", "right"]:
-                axis_key_labels = self.yaxis
-            if axis_key_labels not in self.layout:
-                self.layout[axis_key_labels] = {}
-            self.layout[axis_key_labels]["tickvals"] = [
-                zv * self.sign[axis_key] for zv in self.zero_vals
-            ]
-            self.layout[axis_key_labels]["ticktext"] = self.labels
-            self.layout[axis_key_labels]["tickmode"] = "array"
-
-        self.layout[axis_key].update(axis_defaults)
-
-        return self.layout[axis_key]
-
-    def set_figure_layout(self, width, height):
-        """
-        Sets and returns default layout object for dendrogram figure.
-
-        """
-        self.layout.update(
-            {
-                "showlegend": False,
-                "autosize": False,
-                "hovermode": "closest",
-                "width": width,
-                "height": height,
-            }
-        )
-
-        self.set_axis_layout(self.xaxis)
-        self.set_axis_layout(self.yaxis)
-
-        return self.layout
-
-    def get_dendrogram_traces(
-        self,
-        dist,
-        colorscale,
-        linkagefun,
-        hovertext,
-        color_threshold,
-        count_sort,
-        distance_sort,
-        render_mode,
-    ):
-        """
-        Calculates all the elements needed for plotting a dendrogram.
-
-        :param (ndarray) dist: Distance matrix in condensed form
-        :param (list) colorscale: Color scale for dendrogram tree clusters
-        :param (function) linkagefun: Function to compute the linkage matrix
-                                      from the pairwise distances
-        :param (list) hovertext: List of hovertext for constituent traces of dendrogram
-        :rtype (tuple): Contains all the traces in the following order:
-            (a) trace_list: List of Plotly trace objects for dendrogram tree
-            (b) icoord: All X points of the dendrogram tree as array of arrays
-                with length 4
-            (c) dcoord: All Y points of the dendrogram tree as array of arrays
-                with length 4
-            (d) ordered_labels: leaf labels in the order they are going to
-                appear on the plot
-            (e) P['leaves']: left-to-right traversal of the leaves
-
-        """
-        Z = linkagefun(dist)
-        P = sch.dendrogram(
-            Z,
-            orientation=self.orientation,
-            labels=self.labels,
-            no_plot=True,
-            color_threshold=color_threshold,
-            count_sort=count_sort,
-            distance_sort=distance_sort,
-        )
-
-        icoord = scp.array(P["icoord"])
-        dcoord = scp.array(P["dcoord"])
-        ordered_labels = scp.array(P["ivl"])
-        color_list = scp.array(P["color_list"])
-        colors = self.get_color_dict(colorscale)
-
-        trace_list = []
-
-        for i in range(len(icoord)):
-            # xs and ys are arrays of 4 points that make up the '∩' shapes
-            # of the dendrogram tree
-            if self.orientation in ["top", "bottom"]:
-                xs = icoord[i]
-            else:
-                xs = dcoord[i]
-
-            if self.orientation in ["top", "bottom"]:
-                ys = dcoord[i]
-            else:
-                ys = icoord[i]
-            color_key = color_list[i]
-            hovertext_label = None
-            if hovertext:
-                hovertext_label = hovertext[i]
-            trace = dict(
-                type="scattergl" if render_mode == "webgl" else "scatter",
-                x=np.multiply(self.sign[self.xaxis], xs),
-                y=np.multiply(self.sign[self.yaxis], ys),
-                mode="lines",
-                marker=dict(color=colors[color_key]),
-                text=hovertext_label,
-                hoverinfo="text",
-                showlegend=False,
-            )
-
-            try:
-                x_index = int(self.xaxis[-1])
-            except ValueError:
-                x_index = ""
-
-            try:
-                y_index = int(self.yaxis[-1])
-            except ValueError:
-                y_index = ""
-
-            trace["xaxis"] = "x" + x_index
-            trace["yaxis"] = "y" + y_index
-
-            trace_list.append(trace)
-
-        return trace_list, icoord, dcoord, ordered_labels, P["leaves"]
+    return fig

--- a/notebooks/plot_haplotype_clustering.ipynb
+++ b/notebooks/plot_haplotype_clustering.ipynb
@@ -75,7 +75,6 @@
     "    width=None,\n",
     "    height=500,\n",
     "    count_sort=True,\n",
-    "    render_mode=\"svg\",\n",
     ")"
    ]
   },


### PR DESCRIPTION
This PR swaps out the implementation of plotly dendrogram which was borrowed from the web with a simpler and more performant implementation.

Also switches to using zarr to save data to the results cache to improve performance.

Also fix missing taxon colors for Ag3.

* Resolves #456
* Resolves #466 
