### PR TITLE
Biallelic SNP calls and diplotypes

### DIFF
--- a/malariagen_data/anoph/base.py
+++ b/malariagen_data/anoph/base.py
@@ -78,7 +78,7 @@ class AnophelesBase:
 
         # Get bokeh to output plots to the notebook - this is a common gotcha,
         # users forget to do this and wonder why bokeh plots don't show.
-        if bokeh_output_notebook:
+        if bokeh_output_notebook:  # pragma: no cover
             bokeh.io.output_notebook(hide_banner=True)
 
         # Check colab location is in the US.
@@ -101,26 +101,28 @@ class AnophelesBase:
         if results_cache is not None:
             self._results_cache = Path(results_cache).expanduser().resolve()
 
-    def _progress(self, iterable, desc=None, leave=False, **kwargs):
+    def _progress(self, iterable, desc=None, leave=False, **kwargs):  # pragma: no cover
         # Progress doesn't mix well with debug logging.
         show_progress = self._show_progress and not self._debug
-        if show_progress:  # pragma: no cover
+        if show_progress:
             return tqdm(iterable, desc=desc, leave=leave, **kwargs)
         else:
             return nullcontext()
 
-    def _dask_progress(self, desc=None, leave=False, **kwargs):
+    def _dask_progress(self, desc=None, leave=False, **kwargs):  # pragma: no cover
         # Progress doesn't mix well with debug logging.
         show_progress = self._show_progress and not self._debug
-        if show_progress:  # pragma: no cover
+        if show_progress:
             return TqdmCallback(desc=desc, leave=leave, **kwargs)
         else:
             return nullcontext()
 
-    def _spinner(self, desc=None, spinner=None, side="right", timer=True, **kwargs):
+    def _spinner(
+        self, desc=None, spinner=None, side="right", timer=True, **kwargs
+    ):  # pragma: no cover
         # Progress doesn't mix well with debug logging.
         show_progress = self._show_progress and not self._debug
-        if show_progress:  # pragma: no cover
+        if show_progress:
             if desc:
                 # For consistent behaviour with tqdm.
                 desc += ":"

--- a/malariagen_data/anoph/base.py
+++ b/malariagen_data/anoph/base.py
@@ -107,7 +107,7 @@ class AnophelesBase:
         if show_progress:
             return tqdm(iterable, desc=desc, leave=leave, **kwargs)
         else:
-            return nullcontext()
+            return iterable
 
     def _dask_progress(self, desc=None, leave=False, **kwargs):  # pragma: no cover
         # Progress doesn't mix well with debug logging.

--- a/malariagen_data/anoph/base_params.py
+++ b/malariagen_data/anoph/base_params.py
@@ -245,3 +245,36 @@ gff_attributes: TypeAlias = Annotated[
 ]
 
 DEFAULT: Final[str] = "default"
+
+n_snps: TypeAlias = Annotated[
+    int,
+    """
+    The desired number of SNPs to use when running the analysis.
+    SNPs will be evenly thinned to approximately this number.
+    """,
+]
+
+thin_offset: TypeAlias = Annotated[
+    int,
+    """
+    Starting index for SNP thinning. Change this to repeat the analysis
+    using a different set of SNPs.
+    """,
+]
+
+min_minor_ac: TypeAlias = Annotated[
+    int,
+    """
+    The minimum minor allele count. SNPs with a minor allele count
+    below this value will be excluded prior to thinning.
+    """,
+]
+
+max_missing_an: TypeAlias = Annotated[
+    int,
+    """
+    The maximum number of missing allele calls to accept. SNPs with
+    more than this value will be excluded prior to thinning. Set to 0
+    (default) to require no missing calls.
+    """,
+]

--- a/malariagen_data/anoph/base_params.py
+++ b/malariagen_data/anoph/base_params.py
@@ -266,7 +266,7 @@ min_minor_ac: TypeAlias = Annotated[
     int,
     """
     The minimum minor allele count. SNPs with a minor allele count
-    below this value will be excluded prior to thinning.
+    below this value will be excluded.
     """,
 ]
 
@@ -274,7 +274,7 @@ max_missing_an: TypeAlias = Annotated[
     int,
     """
     The maximum number of missing allele calls to accept. SNPs with
-    more than this value will be excluded prior to thinning. Set to 0
-    (default) to require no missing calls.
+    more than this value will be excluded. Set to 0 to require no
+    missing calls.
     """,
 ]

--- a/malariagen_data/anoph/pca_params.py
+++ b/malariagen_data/anoph/pca_params.py
@@ -4,45 +4,6 @@ import numpy as np
 import pandas as pd
 from typing_extensions import Annotated, TypeAlias
 
-n_snps: TypeAlias = Annotated[
-    int,
-    """
-    The desired number of SNPs to use when running the analysis.
-    SNPs will be evenly thinned to approximately this number.
-    """,
-]
-
-thin_offset: TypeAlias = Annotated[
-    int,
-    """
-    Starting index for SNP thinning. Change this to repeat the analysis
-    using a different set of SNPs.
-    """,
-]
-
-thin_offset_default: thin_offset = 0
-
-min_minor_ac: TypeAlias = Annotated[
-    int,
-    """
-    The minimum minor allele count. SNPs with a minor allele count
-    below this value will be excluded prior to thinning.
-    """,
-]
-
-min_minor_ac_default: min_minor_ac = 2
-
-max_missing_an: TypeAlias = Annotated[
-    int,
-    """
-    The maximum number of missing allele calls to accept. SNPs with
-    more than this value will be excluded prior to thinning. Set to 0
-    (default) to require no missing calls.
-    """,
-]
-
-max_missing_an_default = 0
-
 n_components: TypeAlias = Annotated[
     int,
     "Number of components to return.",

--- a/malariagen_data/anoph/snp_data.py
+++ b/malariagen_data/anoph/snp_data.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import allel
 import bokeh
@@ -1378,8 +1378,8 @@ class AnophelesSnpData(
         ds_bi = ds.isel(variants=loc_bi)
 
         # Start building a new dataset.
-        coords = dict()
-        data_vars = dict()
+        coords: Dict[str, Any] = dict()
+        data_vars: Dict[str, Any] = dict()
 
         # Store sample IDs.
         coords["sample_id"] = ("samples",), ds_bi["sample_id"].data

--- a/notebooks/plot_pca.ipynb
+++ b/notebooks/plot_pca.ipynb
@@ -20,7 +20,7 @@
     "ag3 = malariagen_data.Ag3(\n",
     "    \"simplecache::gs://vo_agam_release\",\n",
     "    simplecache=dict(cache_storage=\"../gcs_cache\"),\n",
-    "    results_cache=\"../results_cache\",\n",
+    "    results_cache=\"results_cache\",\n",
     ")\n",
     "ag3"
    ]
@@ -35,7 +35,7 @@
     "af1 = malariagen_data.Af1(\n",
     "    \"simplecache::gs://vo_afun_release\",\n",
     "    simplecache=dict(cache_storage=\"../gcs_cache\"),\n",
-    "    results_cache=\"../results_cache\",\n",
+    "    results_cache=\"results_cache\",\n",
     ")\n",
     "af1"
    ]
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!rm -rf ../results_cache"
+    "!rm -rf results_cache"
    ]
   },
   {
@@ -293,7 +293,27 @@
    "id": "a1fa72e9-3b9c-4f8d-9979-a19bc2ac76a4",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "gn = ag3.biallelic_diplotypes(\n",
+    "    region=\"3L:1,000,000-1,100,000\",\n",
+    "    sample_sets=\"AG1000G-FR\",\n",
+    "    site_mask=\"gamb_colu_arab\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27c8f7fa-4bf2-4cdb-8895-97670f2cd8bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gn = ag3.biallelic_diplotypes(\n",
+    "    region=\"3L:1,000,000-1,100,000\",\n",
+    "    sample_sets=\"AG1000G-FR\",\n",
+    "    site_mask=\"gamb_colu_arab\",\n",
+    ")"
+   ]
   }
  ],
  "metadata": {

--- a/tests/anoph/test_snp_data.py
+++ b/tests/anoph/test_snp_data.py
@@ -1197,8 +1197,8 @@ def test_biallelic_snp_calls_and_diplotypes_with_conditions(
     site_mask = random.choice((None,) + api.site_mask_ids)
 
     # Parametrise conditions.
-    min_minor_ac = random.randint(1, 5)
-    max_missing_an = random.randint(0, 5)
+    min_minor_ac = random.randint(1, 3)
+    max_missing_an = random.randint(2, 10)
 
     # Run tests.
     ds = check_biallelic_snp_calls_and_diplotypes(
@@ -1223,6 +1223,9 @@ def test_biallelic_snp_calls_and_diplotypes_with_conditions(
 
     # Run tests with thinning.
     n_snps_available = ds.dims["variants"]
+    # This should always be true, although depends on min_minor_ac and max_missing_an,
+    # so the range of values for those parameters needs to be chosen with some case.
+    assert n_snps_available > 2
     n_snps_requested = random.randint(1, n_snps_available // 2)
     ds_thinned = check_biallelic_snp_calls_and_diplotypes(
         api=api,


### PR DESCRIPTION
* Resolves #448 

Adds a new method `biallelic_snp_calls()` which builds a dataset of SNP calls at sites which are biallelic within the selected samples. Note these do not necessarily have to include the reference allele, i.e., sites are included if there are only two alleles observed, regardles of which alleles.

Adds a new method `biallelic_diplotypes()` which computes alternate allele counts per genotype call, generating a 2-dimensional array suitable for use with PCA, neighbour-joining trees, admixture, etc.

Refactors `pca()` to use `biallelic_diplotypes()` internally.

N.B., because the set of input SNPs to PCA will be slightly different as a result of this change, I have bumped the results cache version number for the pca() function. Also the next release of malariagen_data should be a major version bump I would suggest - the API has not changed so code will still be backwards compatible, but analysis results could change slightly and so it would probably help to communicate that.