### PR TITLE
Bokeh BokehDeprecationWarning: 'circle() method with size value' was deprecated in Bokeh 3.4.0 and will be removed, use 'scatter(size=...) instead'

### DIFF
--- a/malariagen_data/anoph/cnv_data.py
+++ b/malariagen_data/anoph/cnv_data.py
@@ -641,8 +641,12 @@ class AnophelesCnvData(
         circle_kwargs_mutable["legend_label"] = circle_kwargs_mutable.get(
             "legend_label", "Coverage"
         )
-        fig.circle(
-            x="variant_midpoint", y="call_NormCov", source=data, **circle_kwargs_mutable
+        fig.scatter(
+            x="variant_midpoint",
+            y="call_NormCov",
+            source=data,
+            marker="circle",
+            **circle_kwargs_mutable,
         )
 
         debug("plot the HMM state")

--- a/malariagen_data/anoph/fst.py
+++ b/malariagen_data/anoph/fst.py
@@ -227,10 +227,11 @@ class AnophelesFstAnalysis(
         )
 
         # plot Fst
-        fig.circle(
+        fig.scatter(
             x=x,
             y=fst,
             size=3,
+            marker="circle",
             line_width=1,
             line_color="black",
             fill_color=None,

--- a/malariagen_data/anoph/g123.py
+++ b/malariagen_data/anoph/g123.py
@@ -377,10 +377,11 @@ class AnophelesG123Analysis(
         )
 
         # plot G123
-        fig.circle(
+        fig.scatter(
             x=x,
             y=g123,
             size=3,
+            marker="circle",
             line_width=1,
             line_color="black",
             fill_color=None,
@@ -557,7 +558,14 @@ class AnophelesG123Analysis(
         fig.line(
             window_sizes, q50, line_color="black", line_width=4, legend_label="median"
         )
-        fig.circle(window_sizes, q50, color="black", fill_color="black", size=8)
+        fig.scatter(
+            window_sizes,
+            q50,
+            marker="circle",
+            color="black",
+            fill_color="black",
+            size=8,
+        )
 
         fig.xaxis.ticker = window_sizes
 

--- a/malariagen_data/anoph/gplt_params.py
+++ b/malariagen_data/anoph/gplt_params.py
@@ -96,7 +96,7 @@ output_backend_default: output_backend = "webgl"
 
 circle_kwargs: TypeAlias = Annotated[
     Mapping,
-    "Passed through to bokeh circle() function.",
+    "Passed through to bokeh scatter() function with marker = 'circle'.",
 ]
 
 line_kwargs: TypeAlias = Annotated[

--- a/malariagen_data/anoph/h12.py
+++ b/malariagen_data/anoph/h12.py
@@ -193,7 +193,14 @@ class AnophelesH12Analysis(
         fig.line(
             window_sizes, q50, line_color="black", line_width=4, legend_label="median"
         )
-        fig.circle(window_sizes, q50, color="black", fill_color="black", size=8)
+        fig.scatter(
+            window_sizes,
+            q50,
+            marker="circle",
+            color="black",
+            fill_color="black",
+            size=8,
+        )
 
         fig.xaxis.ticker = window_sizes
         if show:  # pragma: no cover
@@ -372,9 +379,10 @@ class AnophelesH12Analysis(
         )
 
         # Plot H12.
-        fig.circle(
+        fig.scatter(
             x=x,
             y=h12,
+            marker="circle",
             size=3,
             line_width=1,
             line_color="black",

--- a/malariagen_data/anoph/h1x.py
+++ b/malariagen_data/anoph/h1x.py
@@ -221,9 +221,10 @@ class AnophelesH1XAnalysis(
         )
 
         # Plot H1X.
-        fig.circle(
+        fig.scatter(
             x=x,
             y=h1x,
+            marker="circle",
             size=3,
             line_width=1,
             line_color="black",


### PR DESCRIPTION
Resolves #530 .