### PR TITLE
Updated parasite test buckets from staging to release

### DIFF
--- a/tests/test_pf7_integration.py
+++ b/tests/test_pf7_integration.py
@@ -7,7 +7,7 @@ import xarray
 from malariagen_data.pf7 import Pf7
 
 
-def setup_pf7(url="simplecache::gs://pf7_staging/", **storage_kwargs):
+def setup_pf7(url="simplecache::gs://pf7_release/", **storage_kwargs):
     if url.startswith("simplecache::"):
         storage_kwargs["simplecache"] = dict(cache_storage="gcs_cache")
     return Pf7(url, **storage_kwargs)
@@ -16,12 +16,12 @@ def setup_pf7(url="simplecache::gs://pf7_staging/", **storage_kwargs):
 @pytest.mark.parametrize(
     "url",
     [
-        "gs://pf7_staging/",
-        "gcs://pf7_staging/",
-        "gs://pf7_staging",
-        "gcs://pf7_staging",
-        "simplecache::gs://pf7_staging/",
-        "simplecache::gcs://pf7_staging/",
+        "gs://pf7_release/",
+        "gcs://pf7_release/",
+        "gs://pf7_release",
+        "gcs://pf7_release",
+        "simplecache::gs://pf7_release/",
+        "simplecache::gcs://pf7_release/",
     ],
 )
 def test_sample_metadata(url):

--- a/tests/test_pv4_integration.py
+++ b/tests/test_pv4_integration.py
@@ -7,7 +7,7 @@ import xarray
 from malariagen_data.pv4 import Pv4
 
 
-def setup_pv4(url="simplecache::gs://pv4_staging/", **storage_kwargs):
+def setup_pv4(url="simplecache::gs://pv4_release/", **storage_kwargs):
     if url.startswith("simplecache::"):
         storage_kwargs["simplecache"] = dict(cache_storage="gcs_cache")
     return Pv4(url, **storage_kwargs)
@@ -16,12 +16,12 @@ def setup_pv4(url="simplecache::gs://pv4_staging/", **storage_kwargs):
 @pytest.mark.parametrize(
     "url",
     [
-        "gs://pv4_staging/",
-        "gcs://pv4_staging/",
-        "gs://pv4_staging",
-        "gcs://pv4_staging",
-        "simplecache::gs://pv4_staging/",
-        "simplecache::gcs://pv4_staging/",
+        "gs://pv4_release/",
+        "gcs://pv4_release/",
+        "gs://pv4_release",
+        "gcs://pv4_release",
+        "simplecache::gs://pv4_release/",
+        "simplecache::gcs://pv4_release/",
     ],
 )
 def test_sample_metadata(url):


### PR DESCRIPTION
Updated files containing paths to parasite GCS staging buckets,`test_pf7_integration.py` and `test_pv4_integration.py`, to use release buckets. 