### PR TITLE
Raise ValueError for missing CNV HMM

### DIFF
--- a/malariagen_data/anoph/cnv_data.py
+++ b/malariagen_data/anoph/cnv_data.py
@@ -80,6 +80,12 @@ class AnophelesCnvData(
             release = self.lookup_release(sample_set=sample_set)
             release_path = self._release_to_path(release)
             path = f"{self._base_path}/{release_path}/cnv/{sample_set}/hmm/zarr"
+            # Note: HMM does not exist for all sample sets or analyses.
+            marker = path + "/.zmetadata"
+            if not self._fs.exists(marker):
+                raise ValueError(
+                    f"CNV HMM not implemented for sample set {sample_set!r}"
+                )
             store = init_zarr_store(fs=self._fs, path=path)
             root = zarr.open_consolidated(store=store)
             self._cache_cnv_hmm[sample_set] = root


### PR DESCRIPTION
Re: issue #363

Alternative approach to PR #575

Regarding issue #555, this would still require manual filtering of sample sets that don't have CNV HMM.

The user might not know ahead of time which sample sets have or don't have CNV HMM. 