### PR TITLE
Fix and improve plotting pairwise average fst

### DIFF
--- a/malariagen_data/anoph/plotly_params.py
+++ b/malariagen_data/anoph/plotly_params.py
@@ -26,7 +26,12 @@ fig_width: TypeAlias = Annotated[
 
 fig_height: TypeAlias = Annotated[
     Optional[int],
-    "Figure weight in pixels (px).",
+    "Figure height in pixels (px).",
+]
+
+width: TypeAlias = Annotated[
+    int,
+    "Width in pixels (px).",
 ]
 
 height: TypeAlias = Annotated[

--- a/notebooks/plot_pairwise_average_fst.ipynb
+++ b/notebooks/plot_pairwise_average_fst.ipynb
@@ -24,7 +24,7 @@
     "ag3 = malariagen_data.Ag3(\n",
     "    \"simplecache::gs://vo_agam_release\",\n",
     "    simplecache=dict(cache_storage=\"../gcs_cache\"),\n",
-    "    cohorts_analysis=\"20230516\",\n",
+    "    cohorts_analysis=\"20240717\",\n",
     "    results_cache=\"results_cache\",\n",
     ")\n",
     "ag3"
@@ -90,6 +90,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "35959f42-732e-40fa-86ad-16d95fb6e740",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_pairwise_average_fst(pairwise_fst_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "35d304bd-3f39-4dc7-9f7d-905068d5cd0d",
    "metadata": {},
    "outputs": [],
@@ -110,16 +120,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35959f42-732e-40fa-86ad-16d95fb6e740",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ag3.plot_pairwise_average_fst(pairwise_fst_df, zmax=0.1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "c16035d2-b5d3-4441-87d9-eda953079161",
    "metadata": {},
    "outputs": [],
@@ -130,7 +130,109 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "13afd6ed-7962-4935-b1f1-ed12f5e2ceed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "region=\"3L:15,000,000-16,000,000\"\n",
+    "site_mask='arab'\n",
+    "n_jack=200"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "48a52211-2ef9-47da-b715-d0d74a69a4ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pairwise_fst_df = ag3.pairwise_average_fst(\n",
+    "    region=region,\n",
+    "    cohorts=\"cohort_admin1_year\",\n",
+    "    sample_query=\"country == 'Kenya' and taxon == 'arabiensis'\",\n",
+    "    sample_sets=[\"AG1000G-KE\", \"1274-VO-KE-KAMAU-VMF00246\"],\n",
+    "    n_jack=n_jack,\n",
+    "    site_mask=site_mask,\n",
+    "    min_cohort_size=10,\n",
+    ")\n",
+    "pairwise_fst_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09cc1824-e6f4-4799-a8f4-cf61e472eaf8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_pairwise_average_fst(pairwise_fst_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95f112d2-fe76-4091-b73b-d7a17a61cc18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_pairwise_average_fst(pairwise_fst_df, annotation=\"standard error\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "908b08c8-290f-49d1-b3d3-cb8f9e7d2d21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_pairwise_average_fst(pairwise_fst_df, annotation=\"Z score\", zmax=0.03)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "818fdac7-dcb4-4da2-8a52-f16ce51a2c0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wild_cohorts = {\n",
+    "    \"Mwea_2007\": \"taxon == 'arabiensis' and location == 'Mwea' and year == 2007\",\n",
+    "    \"Mwea_2014\": \"taxon == 'arabiensis' and location == 'Mwea' and year == 2014\",\n",
+    "    \"Teso_2013\": \"taxon == 'arabiensis' and location == 'Teso'\",\n",
+    "    \"Turkana_2006\": \"taxon == 'arabiensis' and location == 'Turkana'\",\n",
+    "    \"Kilifi_2012\": \"taxon == 'arabiensis' and location == 'Kilifi' and year == 2012\",\n",
+    "}\n",
+    "fst_df = ag3.pairwise_average_fst(\n",
+    "    region=\"3L:15,000,000-16,000,000\", \n",
+    "    cohorts=wild_cohorts,\n",
+    "    min_cohort_size=10,\n",
+    "    site_mask=\"arab\",\n",
+    ")\n",
+    "fst_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65c1bdd5-f1d2-4814-93e5-ddb1d9c42258",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_pairwise_average_fst(fst_df, annotation=\"Z score\", zmax=0.4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ec8cfe3-336c-4362-9361-78d40ffa0a8e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d3236a2-842d-4c13-92ec-9a4338750aca",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -152,7 +254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.18"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* Resolves #567.
* Removes warnings associated with pandas chained assignments.
* Dynamically sizes plot based on number of cohorts.
* Adds a title to the plot.
* Disable colouring by default if an annotation is requested in the upper triangle (as the table then contains a mix of two different types of values and the colouring becomes confusing).
* Code simplification.