### PR TITLE
add support for karyotyping

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -351,9 +351,9 @@ class Ag3(AnophelesDataResource):
         return contig, df_tag_snps["pos"].to_numpy()
 
     def karyotype(
-        self, inversion: str, sample_sets=None, sample_query=None
+        self, inversion, sample_sets=None, sample_query=None
     ) -> pd.DataFrame:
-        contig, tag_snps_pos = self.load_inversion_tags(self, inversion)
+        contig, tag_snps_pos = self.load_inversion_tags(self, inversion=inversion)
         start, end = np.min(tag_snps_pos), np.max(tag_snps_pos)
         region = f"{contig}:{start}-{end}"
 

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -353,7 +353,7 @@ class Ag3(AnophelesDataResource):
     def karyotype(
         self, inversion, sample_sets=None, sample_query=None
     ) -> pd.DataFrame:
-        contig, tag_snps_pos = self.load_inversion_tags(self, inversion=inversion)
+        contig, tag_snps_pos = self.load_inversion_tags(inversion=inversion)
         start, end = np.min(tag_snps_pos), np.max(tag_snps_pos)
         region = f"{contig}:{start}-{end}"
 

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -344,30 +344,27 @@ class Ag3(AnophelesDataResource):
         # override parent class to add AIM analysis
         params["aim_analysis"] = self._aim_analysis
 
-
     def load_inversion_tags(self, inversion: str):
-            contig = inversion[0:2]
-            url = f"https://raw.githubusercontent.com/rrlove/compkaryo/master/compkaryo/targets/{inversion}_targets.txt"
-            df_tag_snps = pd.read_csv(url, sep="\t", header=None, names=['pos'])
-            return contig, df_tag_snps['pos'].to_numpy()
+        contig = inversion[0:2]
+        url = f"https://raw.githubusercontent.com/rrlove/compkaryo/master/compkaryo/targets/{inversion}_targets.txt"
+        df_tag_snps = pd.read_csv(url, sep="\t", header=None, names=["pos"])
+        return contig, df_tag_snps["pos"].to_numpy()
 
     def karyotype(
-            self, 
-            inversion: str,  
-            sample_sets=None, 
-            sample_query=None
-            ) -> pd.DataFrame:
-
+        self, inversion: str, sample_sets=None, sample_query=None
+    ) -> pd.DataFrame:
         contig, tag_snps_pos = self.load_inversion_tags(self, inversion)
         start, end = np.min(tag_snps_pos), np.max(tag_snps_pos)
         region = f"{contig}:{start}-{end}"
 
         # compkaryo targets do not specify specific alleles, they assume biallelism, so we need to use biallelic_snp_calls
-        ds_snps = self.biallelic_snp_calls(region=region, sample_sets=sample_sets, sample_query=sample_query)
-        geno = allel.GenotypeDaskArray(ds_snps['call_genotype'].data)
-        pos = ds_snps['variant_position'].values
-        samples = ds_snps['sample_id'].values
-        
+        ds_snps = self.biallelic_snp_calls(
+            region=region, sample_sets=sample_sets, sample_query=sample_query
+        )
+        geno = allel.GenotypeDaskArray(ds_snps["call_genotype"].data)
+        pos = ds_snps["variant_position"].values
+        samples = ds_snps["sample_id"].values
+
         # subset to positions inversion tags
         pos = allel.SortedIndex(pos)
         pos_bool = pos.locate_intersection(tag_snps_pos)[0]
@@ -377,15 +374,18 @@ class Ag3(AnophelesDataResource):
         with self._spinner("Inferring karyotype from tag SNPs"):
             gn_alt = geno.to_n_alt()
             is_called = geno.is_called()
-            
-            # calculate mean genotype for each sample 
-            av_gts = np.mean(np.ma.MaskedArray(gn_alt,
-                                            mask=~is_called), axis=0).data
+
+            # calculate mean genotype for each sample
+            av_gts = np.mean(np.ma.MaskedArray(gn_alt, mask=~is_called), axis=0).data
             total_sites = np.sum(is_called, axis=0)
-            
-            df = pd.DataFrame({'sample_id': samples,
-                               'inversion':inversion,
-                               'mean_tag_snp_genotype': av_gts,
-                               'total_tag_snps':total_sites})
+
+            df = pd.DataFrame(
+                {
+                    "sample_id": samples,
+                    "inversion": inversion,
+                    "mean_tag_snp_genotype": av_gts,
+                    "total_tag_snps": total_sites,
+                }
+            )
 
         return df

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -853,14 +853,10 @@ def test_xpehh_gwss():
     assert_allclose(xpehh[:, 2][100], 0.4817561326426265)
 
 
-
 def test_karyotyping():
     ag3 = setup_ag3(cohorts_analysis="20230516")
 
-    df = ag3.karyotype(
-        inversion='2La',
-        sample_sets="AG1000G-FR",
-        sample_query=None)
-    
+    df = ag3.karyotype(inversion="2La", sample_sets="AG1000G-FR", sample_query=None)
+
     assert isinstance(df, pd.DataFrame)
     assert len(df) > 0

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -851,3 +851,16 @@ def test_xpehh_gwss():
     # check some values
     assert_allclose(x[0], 467448.348)
     assert_allclose(xpehh[:, 2][100], 0.4817561326426265)
+
+
+
+def test_karyotyping():
+    ag3 = setup_ag3(cohorts_analysis="20230516")
+
+    df = ag3.karyotype(
+        inversion='2La',
+        sample_sets="AG1000G-FR",
+        sample_query=None)
+    
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) > 0


### PR DESCRIPTION
Addresses #604 

In this PR, I add support for karyotyping. I have added the functionality to ag3.py, as it is specific to gambiae complex - not for funestus. 

This works by reading in the tag SNPs directly from the compkaryo github (https://github.com/rrlove/compkaryo/tree/master/compkaryo/targets), subsetting to those positions, and calculating the mean genotype, returning a dataframe. Currently, the raw mean genotype is returned, but perhaps we should round it to 0,1,2 which might be less confusing for end users (the tag SNPs are not perfect). 

I use biallelic snp calls only, because the compkaryo tag snps do not specify specific alleles and assume biallelism, which is a problem, because what was biallelic in their data could be multiallelic in yours. Still, they do work fine from what I can see. 

Users may have to be advised that some tag SNPs are applicable only to certain species in the gambiae complex. For example, I have seen people try and report the frequency of tag snps of an inversion which isn't even segregating in their species. In theory we could prevent this within the function, but I'm not sure if that's necessary.  