### PR TITLE
Add parameters to the Anopheles pca function to allow better handling of outliers

### DIFF
--- a/malariagen_data/anoph/pca.py
+++ b/malariagen_data/anoph/pca.py
@@ -71,6 +71,7 @@ class AnophelesPca(
         cohort_size: Optional[base_params.cohort_size] = None,
         min_cohort_size: Optional[base_params.min_cohort_size] = None,
         max_cohort_size: Optional[base_params.max_cohort_size] = None,
+        exclude_samples: Optional[base_params.samples] = None,
         random_seed: base_params.random_seed = 42,
         inline_array: base_params.inline_array = base_params.inline_array_default,
         chunks: base_params.chunks = base_params.chunks_default,
@@ -104,6 +105,7 @@ class AnophelesPca(
             cohort_size=cohort_size,
             min_cohort_size=min_cohort_size,
             max_cohort_size=max_cohort_size,
+            exclude_samples=exclude_samples,
             random_seed=random_seed,
         )
 
@@ -123,7 +125,6 @@ class AnophelesPca(
         # Load sample metadata.
         df_samples = self.sample_metadata(
             sample_sets=sample_sets,
-            sample_indices=sample_indices_prepped,
         )
 
         # Ensure aligned with genotype data.
@@ -153,6 +154,7 @@ class AnophelesPca(
         cohort_size,
         min_cohort_size,
         max_cohort_size,
+        exclude_samples,
         random_seed,
         chunks,
         inline_array,
@@ -175,6 +177,14 @@ class AnophelesPca(
             chunks=chunks,
             inline_array=inline_array,
         )
+
+        # Exclude any samples prior to computing PCA.
+        if exclude_samples is not None:
+            with self._spinner(desc="Exclude samples"):
+                x = np.array(exclude_samples, dtype="U")
+                loc_keep = ~np.isin(samples, x)
+                samples = samples[loc_keep]
+                gn = gn[:, loc_keep]
 
         with self._spinner(desc="Compute PCA"):
             # Remove any sites where all genotypes are identical.

--- a/notebooks/plot_pca.ipynb
+++ b/notebooks/plot_pca.ipynb
@@ -1,6 +1,22 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "7d93e741-bddf-4a29-aea2-7bc6be697cb7",
+   "metadata": {},
+   "source": [
+    "# PCA plotting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f274c61-c660-47b0-92b9-83ab701eb9eb",
+   "metadata": {},
+   "source": [
+    "### Setup"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "36039d6f",
@@ -48,6 +64,14 @@
    "outputs": [],
    "source": [
     "!rm -rf results_cache"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3760474-2ab2-4291-b5ee-48feccd091f4",
+   "metadata": {},
+   "source": [
+    "## Mayotte"
    ]
   },
   {
@@ -138,6 +162,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "467dbd69-8ba2-41a2-8d01-d9fa78d42326",
+   "metadata": {},
+   "source": [
+    "## Burkina Faso"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "6a2ce979-1553-4459-b3c1-f3dea40bc1a1",
@@ -178,6 +210,14 @@
     "    color=\"admin1_year\",\n",
     "    symbol=\"taxon\",\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2b46eb9-832d-417c-a082-9fc365b0fc62",
+   "metadata": {},
+   "source": [
+    "## Ag3.0"
    ]
   },
   {
@@ -321,6 +361,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "14d04103-2f6f-4f53-8d35-f286de5980d2",
+   "metadata": {},
+   "source": [
+    "## Af1.0"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "6c3fc8d5",
@@ -374,12 +422,72 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "fdfbcd5a-5ef4-4cbc-b430-c0b541925142",
+   "metadata": {},
+   "source": [
+    "## Excluding samples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba82766e-f752-4c91-8c22-f85f32a0428a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -rf results_cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa3947da-f32e-44e2-bb6e-7bffc46e778a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import malariagen_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27fb6435-c02a-4b63-a321-dccb962f278e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3 = malariagen_data.Ag3(\n",
+    "    \"simplecache::gs://vo_agam_release\",\n",
+    "    simplecache=dict(cache_storage=\"../gcs_cache\"),\n",
+    "    results_cache=\"results_cache\",\n",
+    ")\n",
+    "ag3"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "6c3251e2-a95c-4d4a-bff1-8e632be0eaf5",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "df_pca, evr = ag3.pca(\n",
+    "    region=\"3L:15,000,000-16,000,000\",\n",
+    "    sample_sets=\"AG1000G-BF-A\",\n",
+    "    n_snps=10_000,\n",
+    "    max_cohort_size=50,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e370936-925a-4e97-86cb-b22f72b39e64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_pca_variance(evr)"
+   ]
   },
   {
    "cell_type": "code",
@@ -387,12 +495,64 @@
    "id": "9ea24435-d752-4269-a391-b057e1650d44",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "ag3.plot_pca_coords(\n",
+    "    df_pca,\n",
+    "    color=\"taxon\",\n",
+    ")"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "1746f075-8b25-47fc-8f97-35093d8cc899",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_pca_ex, evr_ex = ag3.pca(\n",
+    "    region=\"3L:15,000,000-16,000,000\",\n",
+    "    sample_sets=\"AG1000G-BF-A\",\n",
+    "    n_snps=10_000,\n",
+    "    max_cohort_size=50,\n",
+    "    exclude_samples=[\"AB0096-C\", \"AB0241-C\", \"AB02750C\", \"AB0197-C\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "770b01ee-642e-4903-93fa-eef084924234",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_pca_variance(evr_ex)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9438fd91-b463-4d28-8279-5eaa728a8f2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_pca_coords(\n",
+    "    df_pca_ex,\n",
+    "    color=\"taxon\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58e7b2c1-b4c1-4c93-823c-8531693636e4",
+   "metadata": {},
+   "source": [
+    "## Excluding samples during fit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9feb94d-4ebf-4a81-bc40-a5840caa0293",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -414,11 +574,182 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.18"
+   "version": "3.10.12"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
-    "state": {},
+    "state": {
+     "14df74d18db54df896263bfad27f6af0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_75e54883fdfa486aba90b743bd967854",
+       "style": "IPY_MODEL_e644f5f6a81e424cbca42786f26688f9",
+       "value": "Compute SNP allele counts:  94%"
+      }
+     },
+     "1bc41570790a405d859fd7af512fa851": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2b4504cbd92b45389f486b79b07d8e38": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e18a4909e31e4499847fdf6242430bff",
+       "style": "IPY_MODEL_815497cf8e3e4d8989bd4c8bc3d3379c",
+       "value": "Compute biallelic diplotypes:  91%"
+      }
+     },
+     "318fab294a694945ae5251c6fc08500c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_8fbb498a20d24763ba9b3611721aa395",
+       "max": 51,
+       "style": "IPY_MODEL_1bc41570790a405d859fd7af512fa851",
+       "value": 51
+      }
+     },
+     "6527546f7ab74287ac58e984926c1512": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "visibility": "hidden"
+      }
+     },
+     "75e54883fdfa486aba90b743bd967854": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7690103221814c94a3b3504e004039e0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "visibility": "hidden"
+      }
+     },
+     "7973acef3c4c4e46961faec85903ed8b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "815497cf8e3e4d8989bd4c8bc3d3379c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "8d4c64e36f36477a9b324e564482470b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8fbb498a20d24763ba9b3611721aa395": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a4049f11310c4d6e84c35e0c764f5b13": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a58266c1624548d1a890f2f3016f797a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7973acef3c4c4e46961faec85903ed8b",
+       "style": "IPY_MODEL_ac882e01ebe64accb4082331dc31b4dc",
+       "value": " 53/58 [00:01&lt;00:00, 37.31it/s]"
+      }
+     },
+     "ac882e01ebe64accb4082331dc31b4dc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "cbd00b8446b14796a6a9b0f21461604d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d364d6a656064d9eb82bca1aadd09a94": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "e18a4909e31e4499847fdf6242430bff": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e644f5f6a81e424cbca42786f26688f9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "f6ebd0d21ca544efbf4bc077a48d8749": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8d4c64e36f36477a9b324e564482470b",
+       "style": "IPY_MODEL_d364d6a656064d9eb82bca1aadd09a94",
+       "value": " 48/51 [00:01&lt;00:00, 33.73it/s]"
+      }
+     },
+     "fa836f50ca5549afaee67afaddd9df7b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "layout": "IPY_MODEL_cbd00b8446b14796a6a9b0f21461604d",
+       "max": 58,
+       "style": "IPY_MODEL_a4049f11310c4d6e84c35e0c764f5b13",
+       "value": 58
+      }
+     }
+    },
     "version_major": 2,
     "version_minor": 0
    }

--- a/notebooks/plot_pca.ipynb
+++ b/notebooks/plot_pca.ipynb
@@ -432,41 +432,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba82766e-f752-4c91-8c22-f85f32a0428a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!rm -rf results_cache"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fa3947da-f32e-44e2-bb6e-7bffc46e778a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import malariagen_data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "27fb6435-c02a-4b63-a321-dccb962f278e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ag3 = malariagen_data.Ag3(\n",
-    "    \"simplecache::gs://vo_agam_release\",\n",
-    "    simplecache=dict(cache_storage=\"../gcs_cache\"),\n",
-    "    results_cache=\"results_cache\",\n",
-    ")\n",
-    "ag3"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "6c3251e2-a95c-4d4a-bff1-8e632be0eaf5",
    "metadata": {},
    "outputs": [],
@@ -477,6 +442,16 @@
     "    n_snps=10_000,\n",
     "    max_cohort_size=50,\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f0b88a7-d9f6-44a8-9778-4cbaad397765",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_pca.head()"
    ]
   },
   {
@@ -505,17 +480,39 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1746f075-8b25-47fc-8f97-35093d8cc899",
+   "id": "0f114dd9-965d-4579-8cce-76f45fde6a37",
    "metadata": {},
    "outputs": [],
    "source": [
+    "exclude_samples = [\"AB0096-C\", \"AB0241-C\", \"AB0275-C\", \"AB0197-C\"]\n",
+    "\n",
     "df_pca_ex, evr_ex = ag3.pca(\n",
     "    region=\"3L:15,000,000-16,000,000\",\n",
     "    sample_sets=\"AG1000G-BF-A\",\n",
     "    n_snps=10_000,\n",
     "    max_cohort_size=50,\n",
-    "    exclude_samples=[\"AB0096-C\", \"AB0241-C\", \"AB02750C\", \"AB0197-C\"],\n",
+    "    exclude_samples=exclude_samples,\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5392844-a828-48f3-8222-bfc1817c3493",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_pca_ex.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d87eeb5-8dc6-4a31-a8a3-e936d4d05215",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_pca_ex.query(f\"sample_id in {exclude_samples}\")"
    ]
   },
   {
@@ -552,7 +549,81 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9feb94d-4ebf-4a81-bc40-a5840caa0293",
+   "id": "1014a17c-12bb-46c3-9a7b-f2449d205ce3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fit_exclude_samples = [\"AB0096-C\", \"AB0241-C\", \"AB0275-C\", \"AB0197-C\"]\n",
+    "\n",
+    "df_pca_fex, evr_fex = ag3.pca(\n",
+    "    region=\"3L:15,000,000-16,000,000\",\n",
+    "    sample_sets=\"AG1000G-BF-A\",\n",
+    "    n_snps=10_000,\n",
+    "    max_cohort_size=50,\n",
+    "    fit_exclude_samples=fit_exclude_samples,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e48d46dd-5c7f-4573-a5f5-c15a389d2e1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_pca_fex.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1fb5192e-f63f-443d-91a9-e82b2de14c69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_pca_fex.query(f\"sample_id in {fit_exclude_samples}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "873c53f5-8690-4690-85f0-8ce1845e2862",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_pca_variance(evr_fex)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bb86ba2-e428-4ae0-9e0c-703345c89324",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_pca_coords(\n",
+    "    df_pca_fex,\n",
+    "    color=\"taxon\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b28c4c8-9382-4889-8651-77ef0be929f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ag3.plot_pca_coords(\n",
+    "    df_pca_fex,\n",
+    "    color=\"pca_fit\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33d788a2-f256-4930-b1e5-b4f31e681a36",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -578,178 +649,7 @@
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
-    "state": {
-     "14df74d18db54df896263bfad27f6af0": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_75e54883fdfa486aba90b743bd967854",
-       "style": "IPY_MODEL_e644f5f6a81e424cbca42786f26688f9",
-       "value": "Compute SNP allele counts:  94%"
-      }
-     },
-     "1bc41570790a405d859fd7af512fa851": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "2b4504cbd92b45389f486b79b07d8e38": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_e18a4909e31e4499847fdf6242430bff",
-       "style": "IPY_MODEL_815497cf8e3e4d8989bd4c8bc3d3379c",
-       "value": "Compute biallelic diplotypes:  91%"
-      }
-     },
-     "318fab294a694945ae5251c6fc08500c": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "layout": "IPY_MODEL_8fbb498a20d24763ba9b3611721aa395",
-       "max": 51,
-       "style": "IPY_MODEL_1bc41570790a405d859fd7af512fa851",
-       "value": 51
-      }
-     },
-     "6527546f7ab74287ac58e984926c1512": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "visibility": "hidden"
-      }
-     },
-     "75e54883fdfa486aba90b743bd967854": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "7690103221814c94a3b3504e004039e0": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "visibility": "hidden"
-      }
-     },
-     "7973acef3c4c4e46961faec85903ed8b": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "815497cf8e3e4d8989bd4c8bc3d3379c": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "8d4c64e36f36477a9b324e564482470b": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "8fbb498a20d24763ba9b3611721aa395": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "a4049f11310c4d6e84c35e0c764f5b13": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "ProgressStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "a58266c1624548d1a890f2f3016f797a": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_7973acef3c4c4e46961faec85903ed8b",
-       "style": "IPY_MODEL_ac882e01ebe64accb4082331dc31b4dc",
-       "value": " 53/58 [00:01&lt;00:00, 37.31it/s]"
-      }
-     },
-     "ac882e01ebe64accb4082331dc31b4dc": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "cbd00b8446b14796a6a9b0f21461604d": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "d364d6a656064d9eb82bca1aadd09a94": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "e18a4909e31e4499847fdf6242430bff": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "e644f5f6a81e424cbca42786f26688f9": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLStyleModel",
-      "state": {
-       "description_width": "",
-       "font_size": null,
-       "text_color": null
-      }
-     },
-     "f6ebd0d21ca544efbf4bc077a48d8749": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_8d4c64e36f36477a9b324e564482470b",
-       "style": "IPY_MODEL_d364d6a656064d9eb82bca1aadd09a94",
-       "value": " 48/51 [00:01&lt;00:00, 33.73it/s]"
-      }
-     },
-     "fa836f50ca5549afaee67afaddd9df7b": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "2.0.0",
-      "model_name": "FloatProgressModel",
-      "state": {
-       "layout": "IPY_MODEL_cbd00b8446b14796a6a9b0f21461604d",
-       "max": 58,
-       "style": "IPY_MODEL_a4049f11310c4d6e84c35e0c764f5b13",
-       "value": 58
-      }
-     }
-    },
+    "state": {},
     "version_major": 2,
     "version_minor": 0
    }

--- a/tests/anoph/test_pca.py
+++ b/tests/anoph/test_pca.py
@@ -211,5 +211,75 @@ def test_pca_exclude_samples(fixture, api: AnophelesPca):
             "n_snps",
             n_snps,
         )
+    assert "pca_fit" in pca_df.columns
+    assert pca_df["pca_fit"].all()
     assert pca_evr.ndim == 1
     assert pca_evr.shape[0] == n_components
+
+    # Check exclusions.
+    assert len(pca_df.query(f"sample_id in {exclude_samples}")) == 0
+
+
+@parametrize_with_cases("fixture,api", cases=".")
+def test_pca_fit_exclude_samples(fixture, api: AnophelesPca):
+    # Parameters for selecting input data.
+    all_sample_sets = api.sample_sets()["sample_set"].to_list()
+    data_params = dict(
+        region=random.choice(api.contigs),
+        sample_sets=random.sample(all_sample_sets, 2),
+        site_mask=random.choice((None,) + api.site_mask_ids),
+    )
+    ds = api.biallelic_snp_calls(
+        min_minor_ac=pca_params.min_minor_ac_default,
+        max_missing_an=pca_params.max_missing_an_default,
+        **data_params,
+    )
+
+    # Exclusion parameters.
+    n_samples_excluded = random.randint(1, 5)
+    samples = ds["sample_id"].values.tolist()
+    exclude_samples = random.sample(samples, n_samples_excluded)
+
+    # PCA parameters.
+    n_samples = ds.sizes["samples"]
+    n_snps_available = ds.sizes["variants"]
+    n_snps = random.randint(1, n_snps_available)
+    n_components = random.randint(3, min(n_samples, n_snps))
+
+    # Run the PCA.
+    pca_df, pca_evr = api.pca(
+        n_snps=n_snps,
+        n_components=n_components,
+        fit_exclude_samples=exclude_samples,
+        **data_params,
+    )
+
+    # Check types.
+    assert isinstance(pca_df, pd.DataFrame)
+    assert isinstance(pca_evr, np.ndarray)
+
+    # Check sizes.
+    assert len(pca_df) == n_samples
+    for i in range(n_components):
+        assert f"PC{i+1}" in pca_df.columns, (
+            "n_components",
+            n_components,
+            "n_samples",
+            n_samples,
+            "n_snps_available",
+            n_snps_available,
+            "n_snps",
+            n_snps,
+        )
+    assert "pca_fit" in pca_df.columns
+    assert pca_evr.ndim == 1
+    assert pca_evr.shape[0] == n_components
+
+    # Check exclusions.
+    assert not pca_df["pca_fit"].all()
+    assert pca_df["pca_fit"].sum() == n_samples - n_samples_excluded
+    assert len(pca_df.query(f"sample_id in {exclude_samples}")) == n_samples_excluded
+    assert (
+        len(pca_df.query(f"sample_id in {exclude_samples} and not pca_fit"))
+        == n_samples_excluded
+    )

--- a/tests/anoph/test_pca.py
+++ b/tests/anoph/test_pca.py
@@ -184,7 +184,7 @@ def test_pca_exclude_samples(fixture, api: AnophelesPca):
     n_samples = ds.sizes["samples"] - n_samples_excluded
     n_snps_available = ds.sizes["variants"]
     n_snps = random.randint(1, n_snps_available)
-    n_components = random.randint(3, min(n_samples, n_snps))
+    n_components = random.randint(3, min(n_samples, n_snps, 10))
 
     # Run the PCA.
     pca_df, pca_evr = api.pca(
@@ -211,6 +211,7 @@ def test_pca_exclude_samples(fixture, api: AnophelesPca):
             "n_snps",
             n_snps,
         )
+    assert f"PC{n_components+1}" not in pca_df.columns
     assert "pca_fit" in pca_df.columns
     assert pca_df["pca_fit"].all()
     assert pca_evr.ndim == 1
@@ -244,7 +245,7 @@ def test_pca_fit_exclude_samples(fixture, api: AnophelesPca):
     n_samples = ds.sizes["samples"]
     n_snps_available = ds.sizes["variants"]
     n_snps = random.randint(1, n_snps_available)
-    n_components = random.randint(3, min(n_samples, n_snps))
+    n_components = random.randint(3, min(n_samples, n_snps, 10))
 
     # Run the PCA.
     pca_df, pca_evr = api.pca(
@@ -271,6 +272,7 @@ def test_pca_fit_exclude_samples(fixture, api: AnophelesPca):
             "n_snps",
             n_snps,
         )
+    assert f"PC{n_components+1}" not in pca_df.columns
     assert "pca_fit" in pca_df.columns
     assert pca_evr.ndim == 1
     assert pca_evr.shape[0] == n_components

--- a/tests/anoph/test_pca.py
+++ b/tests/anoph/test_pca.py
@@ -158,3 +158,58 @@ def test_pca_plotting(fixture, api: AnophelesPca):
             symbol=symbol,
         )
         assert isinstance(fig_3d, go.Figure)
+
+
+@parametrize_with_cases("fixture,api", cases=".")
+def test_pca_exclude_samples(fixture, api: AnophelesPca):
+    # Parameters for selecting input data.
+    all_sample_sets = api.sample_sets()["sample_set"].to_list()
+    data_params = dict(
+        region=random.choice(api.contigs),
+        sample_sets=random.sample(all_sample_sets, 2),
+        site_mask=random.choice((None,) + api.site_mask_ids),
+    )
+    ds = api.biallelic_snp_calls(
+        min_minor_ac=pca_params.min_minor_ac_default,
+        max_missing_an=pca_params.max_missing_an_default,
+        **data_params,
+    )
+
+    # Exclusion parameters.
+    n_samples_excluded = random.randint(1, 5)
+    samples = ds["sample_id"].values.tolist()
+    exclude_samples = random.sample(samples, n_samples_excluded)
+
+    # PCA parameters.
+    n_samples = ds.sizes["samples"] - n_samples_excluded
+    n_snps_available = ds.sizes["variants"]
+    n_snps = random.randint(1, n_snps_available)
+    n_components = random.randint(3, min(n_samples, n_snps))
+
+    # Run the PCA.
+    pca_df, pca_evr = api.pca(
+        n_snps=n_snps,
+        n_components=n_components,
+        exclude_samples=exclude_samples,
+        **data_params,
+    )
+
+    # Check types.
+    assert isinstance(pca_df, pd.DataFrame)
+    assert isinstance(pca_evr, np.ndarray)
+
+    # Check sizes.
+    assert len(pca_df) == n_samples
+    for i in range(n_components):
+        assert f"PC{i+1}" in pca_df.columns, (
+            "n_components",
+            n_components,
+            "n_samples",
+            n_samples,
+            "n_snps_available",
+            n_snps_available,
+            "n_snps",
+            n_snps,
+        )
+    assert pca_evr.ndim == 1
+    assert pca_evr.shape[0] == n_components


### PR DESCRIPTION
This PR adds two new parameters to the Anopheles `pca()` function to help with situations where you have PCA outliers that need to be excluded:

* `exclude_samples` - This parameter can be a list of samples that will be excluded completely from the PCA analysis.
* `fit_exclude_samples` - This parameter can be a list of samples that will be excluded during the fitting stage of the PCA analysis, but will be included in the projection stage and therefore in the resulting output dataframe.

The `fit_exclude_samples` parameter is particularly useful where you have samples that are outliers but you still want to see where they fall within real geographical or taxonomic structure.

Note that both of these parameters are only applied after the loading of the input data (biallelic diplotypes) has been computed. This input data will be cached if a `results_cache` has been set, meaning that making changes to either of these parameters then rerunning the function should be relatively quick.

Resolves #389.