### PR TITLE
Support fractions for max_missing_an and min_minor_ac parameters when accessing biallelic SNPs

### DIFF
--- a/malariagen_data/anoph/base_params.py
+++ b/malariagen_data/anoph/base_params.py
@@ -271,19 +271,21 @@ thin_offset: TypeAlias = Annotated[
 ]
 
 min_minor_ac: TypeAlias = Annotated[
-    int,
+    Union[int, float],
     """
     The minimum minor allele count. SNPs with a minor allele count
-    below this value will be excluded.
+    below this value will be excluded. Can also be a float, which will
+    be interpreted as a fraction.
     """,
 ]
 
 max_missing_an: TypeAlias = Annotated[
-    int,
+    Union[int, float],
     """
     The maximum number of missing allele calls to accept. SNPs with
     more than this value will be excluded. Set to 0 to require no
-    missing calls.
+    missing calls. Can also be a float, which will be interpreted as
+    a fraction.
     """,
 ]
 

--- a/malariagen_data/anoph/snp_data.py
+++ b/malariagen_data/anoph/snp_data.py
@@ -1659,18 +1659,26 @@ class AnophelesSnpData(
             # Apply conditions.
             if max_missing_an is not None or min_minor_ac is not None:
                 loc_out = np.ones(ds_out.sizes["variants"], dtype=bool)
+                an = ac_out.sum(axis=1)
 
                 # Apply missingness condition.
                 if max_missing_an is not None:
-                    an = ac_out.sum(axis=1)
                     an_missing = (ds_out.sizes["samples"] * ds_out.sizes["ploidy"]) - an
-                    loc_missing = an_missing <= max_missing_an
+                    if isinstance(max_missing_an, float):
+                        an_missing_frac = an_missing / an
+                        loc_missing = an_missing_frac <= max_missing_an
+                    else:
+                        loc_missing = an_missing <= max_missing_an
                     loc_out &= loc_missing
 
                 # Apply minor allele count condition.
                 if min_minor_ac is not None:
                     ac_minor = ac_out.min(axis=1)
-                    loc_minor = ac_minor >= min_minor_ac
+                    if isinstance(min_minor_ac, float):
+                        ac_minor_frac = ac_minor / an
+                        loc_minor = ac_minor_frac >= min_minor_ac
+                    else:
+                        loc_minor = ac_minor >= min_minor_ac
                     loc_out &= loc_minor
 
                 ds_out = ds_out.isel(variants=loc_out)


### PR DESCRIPTION
* Resolves #572 