### PR TITLE
Add SNP browser

### DIFF
--- a/malariagen_data/anoph/snp_frq.py
+++ b/malariagen_data/anoph/snp_frq.py
@@ -1277,7 +1277,7 @@ class AnophelesSnpFrequencyAnalysis(
         array_of_snps = np.array(list_of_snps)
 
         # Get the SNP frequencies as a DataFrame.
-        snp_freqs = self._any_snp_allele_freq(region, array_of_snps)
+        snp_freqs = self._any_snp_allele_freq(region, array_of_snps, sample_sets=sample_sets, sample_query=sample_query, site_mask=site_mask)
 
         # Return a copy of the DataFrame to insulate against changes.
         return snp_freqs.copy()

--- a/malariagen_data/anoph/snp_frq.py
+++ b/malariagen_data/anoph/snp_frq.py
@@ -1449,12 +1449,8 @@ class AnophelesSnpFrequencyAnalysis(
         if cohorts is None:
             # Create cohorts full all samples, then each species, then each country x species combo
             # FIXME: this needs to be made agnostic to species groups, e.g. funestus.
-            coh_dict1 = {
-                "all": np.full(num_samples, True),
-                "gambiae": df_samples.taxon == "gambiae",
-                "coluzzii": df_samples.taxon == "coluzzii",
-                "arabiensis": df_samples.taxon == "arabiensis",
-            }
+            coh_dict1 = {t : df_samples.taxon == t for t in np.unique(df_samples.taxon)}
+            coh_dict1['all'] = np.full(num_samples, True)
             coh_dict2 = {
                 c: df_samples.country == c for c in np.unique(df_samples.country)
             }

--- a/malariagen_data/anoph/snp_frq.py
+++ b/malariagen_data/anoph/snp_frq.py
@@ -1269,6 +1269,9 @@ class AnophelesSnpFrequencyAnalysis(
         *,
         list_of_snps: List[int],
         contig: base_params.contig,
+        sample_sets=None,
+        sample_query=None,
+        site_mask=None
     ) -> pd.DataFrame:
         # Compose the region using the min and max SNP positions.
         region = f"{contig}:{min(list_of_snps)}-{max(list_of_snps)}"


### PR DESCRIPTION
Re: issue #563


Hi @EricRLucas , @sanjaynagi , @alimanfoo

Here's a draft PR that incorporates the code from @EricRLucas's Colab notebook, just to provide a proof-of-concept and a straw-man prototype.

The general idea, to quote the issue is to give us:
> some way in malariagen_data to put in a bunch of snp position and get information on snp effect, allele frequencies, and a plot with the genomic context for the snps

However, it's clear that we still need to define the precise requirements and specify the behaviour in more detail. I will need some guidance on that, since I'm not very familiar with the specific use cases, etc.

As it stands, which is very much work in progress and open to comments and discussion, this implementation would provide a few new functions:
1) `snp_browser`, which takes a list of SNP positions and a contig name, and returns a Bokeh plot of the genes on the contig (using `plot_genes`) along with the given SNP positions coloured by their SNP effect, e.g. red for non-synonymous. 
2) `snp_freqs`, which also takes a list of SNP positions and a contig name, but returns a DataFrame containing the SNP frequencies for every allele at every position in the given contig, along with the SNP effect, impact, transcript, etc.
3) `snp_freqs_styled`, which returns a styled DataFrame (Styler object) that includes SNP frequencies coloured according to their value, and SNP effects coloured according to their type. 

These functions can be called in the following way, to effectively replicate the original Colab demo:
```python
import malariagen_data
ag3 = malariagen_data.Ag3()
list_of_snps = [28439294,28439830,28441004,28441038,28441062,28441261,28441637,28442886,28443076,28443204,28443615,28443671,28444974,28445027,28447012,28447524,28448227,28448524,28448698,28450330,28450649,28451169,28454362,28454790,28455838,28456044,28458165,28458776,28458790,28458809,28459999,28460127,28460712,28462387,28462494,28462954,28465913,28466872,28467008,28467686,28467860,28468704,28469065,28471707,28473673,28474453,28493647,28493982,28494698,28495340,28495917]
contig='2R'
```
```python
ag3.snp_browser(
  list_of_snps=list_of_snps,
  contig=contig
)
```
```python
import pandas as pd
pd.set_option('display.max_columns', None)
pd.set_option('display.max_rows', None)
ag3.snp_freqs_styled(
  list_of_snps=list_of_snps,
  contig=contig
)
```

There is the question of whether this functionally makes sense being embedded into the package, as opposed to providing a notebook that demonstrates how to achieve this using existing functionality. My personal reading is that there is evidently a call for us to integrate this functionality, in some form, if only for convenience, but there is also a desire to do it in the right way.

The naming of the functions and their arguments given here, even the placement of the code within the `AnophelesSnpFrequencyAnalysis` class (`anoph/snp_frq.py` module), is completely open for debate, just like everything else! There will be some technical restraints, of course, but generally the code will need to be harmonious with the rest of the package. 

I'm very conscious that this is basically just a copy-and-paste, so far, just to get the ball rolling, so I expect there is still lots of room for rewriting, refactoring, renaming and rejigging, to improve the code and make it fit in better with its surroundings. For example, the code will need to be adapted to also cater for other species groups, such as funestus (Af1).

Please feel free to make a PR on this PR, or submit your own new PRs, or anything else to help move this in the right direction, even if it's towards the bin! I'm also more than happy to update this PR accordingly, in response to any comments or suggestions.
