### PR TITLE
Replace np.in1d with np.isin in g123.py

### DIFF
--- a/malariagen_data/anoph/g123.py
+++ b/malariagen_data/anoph/g123.py
@@ -80,7 +80,7 @@ class AnophelesG123Analysis(
                     inline_array=True,
                     chunks="native",
                 ).compute()
-                hap_site_mask = np.in1d(pos, haplotype_pos, assume_unique=True)
+                hap_site_mask = np.isin(pos, haplotype_pos, assume_unique=True)
                 pos = pos[hap_site_mask]
                 gt = gt.compress(hap_site_mask, axis=0)
 


### PR DESCRIPTION
Re: issue #609

Avoids `DeprecationWarning` raised by `anoph/g123.py`: "`in1d` is deprecated. Use `np.isin` instead."