### PR TITLE
sort gff in `genome_features()`

### DIFF
--- a/malariagen_data/anoph/genome_features.py
+++ b/malariagen_data/anoph/genome_features.py
@@ -149,11 +149,12 @@ class AnophelesGenomeFeaturesData(AnophelesGenomeSequenceData):
                         df_part = df_part.query(f"end >= {r.start}")
                     parts.append(df_part)
                 df = pd.concat(parts, axis=0)
-                return df.reset_index(drop=True).copy()
+                return df.reset_index(drop=True).sort_values(['contig', 'start']).copy()
 
             return (
                 self._genome_features(attributes=attributes_normed)
                 .reset_index(drop=True)
+                .sort_values(['contig', 'start'])
                 .copy()
             )
 

--- a/malariagen_data/anoph/genome_features.py
+++ b/malariagen_data/anoph/genome_features.py
@@ -149,12 +149,12 @@ class AnophelesGenomeFeaturesData(AnophelesGenomeSequenceData):
                         df_part = df_part.query(f"end >= {r.start}")
                     parts.append(df_part)
                 df = pd.concat(parts, axis=0)
-                return df.reset_index(drop=True).sort_values(['contig', 'start']).copy()
+                return df.reset_index(drop=True).sort_values(["contig", "start"]).copy()
 
             return (
                 self._genome_features(attributes=attributes_normed)
                 .reset_index(drop=True)
-                .sort_values(['contig', 'start'])
+                .sort_values(["contig", "start"])
                 .copy()
             )
 

--- a/malariagen_data/anoph/genome_features.py
+++ b/malariagen_data/anoph/genome_features.py
@@ -149,12 +149,12 @@ class AnophelesGenomeFeaturesData(AnophelesGenomeSequenceData):
                         df_part = df_part.query(f"end >= {r.start}")
                     parts.append(df_part)
                 df = pd.concat(parts, axis=0)
-                return df.reset_index(drop=True).sort_values(["contig", "start"]).copy()
+                return df.sort_values(["contig", "start"]).reset_index(drop=True).copy()
 
             return (
                 self._genome_features(attributes=attributes_normed)
-                .reset_index(drop=True)
                 .sort_values(["contig", "start"])
+                .reset_index(drop=True)
                 .copy()
             )
 


### PR DESCRIPTION
To resolve #558 . 

Currently the funestus GFF is not properly sorted, and so when doing advanced diplotype clustering, the genes are displayed in the wrong order, making it difficult to infer patterns and spans of CNVs. 

Now we sort the GFF by contig, start in the genome_features() function. 