### PR TITLE
Better error message for gene_cnv_frequencies() if no cohorts are available for the given sample selection parameters

### DIFF
--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -1183,6 +1183,11 @@ class AnophelesDataResource(
 
                 freq_cols[f"frq_{coh}"] = np.concatenate([amp_freq_coh, del_freq_coh])
 
+        if len(coh_dict) == 0:
+            raise ValueError(
+                "No cohorts available for the given sample selection parameters and minimum cohort size."
+            )
+
         debug("build a dataframe with the frequency columns")
         df_freqs = pd.DataFrame(freq_cols)
 


### PR DESCRIPTION
Resolves #667.

It should pass all tests, mostly because there are no CNV frequencies tests yet. 