### PR TITLE
Ensure that missing CNVs are shown in a different colour in `plot_diplotype_clustering_advanced`

### DIFF
--- a/malariagen_data/anoph/cnv_data.py
+++ b/malariagen_data/anoph/cnv_data.py
@@ -821,7 +821,6 @@ class AnophelesCnvData(
         debug = self._log.debug
 
         import bokeh.models as bkmod
-        import bokeh.palettes as bkpal
         import bokeh.plotting as bkplt
 
         region_prepped: Region = parse_single_region(self, region)
@@ -888,7 +887,7 @@ class AnophelesCnvData(
         )
 
         debug("set up palette and color mapping")
-        palette = ("#cccccc",) + bkpal.PuOr5
+        palette = cnv_params.colorscale_default
         color_mapper = bkmod.LinearColorMapper(low=-1.5, high=4.5, palette=palette)
 
         debug("plot the HMM copy number data as an image")

--- a/malariagen_data/anoph/cnv_params.py
+++ b/malariagen_data/anoph/cnv_params.py
@@ -20,3 +20,6 @@ coverage_calls_analysis: TypeAlias = Annotated[
     `coverage_calls_analysis_ids` property for available values.
     """,
 ]
+
+# This is grey followed by PuOr5
+colorscale_default = ["#cccccc", "#5e3c99", "#b2abd2", "#f7f7f7", "#fdb863", "#e66101"]

--- a/malariagen_data/anoph/dipclust.py
+++ b/malariagen_data/anoph/dipclust.py
@@ -425,6 +425,8 @@ class AnophelesDipClustAnalysis(AnophelesSnpFrequencyAnalysis, AnophelesCnvData)
             n if not pd.isna(n) else gene_ids[i] for i, n in enumerate(gene_names)
         ]
 
+        cn_mode_no_nan = np.nan_to_num(cn_mode, nan=-1)
+
         # Plot the copy number data.
         # N.B., here we have to use go.Heatmap directly rather than
         # px.imshow because the latter fails to incorporate zmin,
@@ -432,9 +434,9 @@ class AnophelesDipClustAnalysis(AnophelesSnpFrequencyAnalysis, AnophelesCnvData)
         # then get lost later when we try to combined into a single
         # figure.
         trace = go.Heatmap(
-            z=cn_mode,
+            z=cn_mode_no_nan,
             y=gene_labels,
-            zmin=0,
+            zmin=-1,
             zmax=4,
             colorscale=colorscale,
             showlegend=False,
@@ -564,7 +566,7 @@ class AnophelesDipClustAnalysis(AnophelesSnpFrequencyAnalysis, AnophelesCnvData)
         snp_filter_min_maf: float = 0.05,
         snp_query: Optional[base_params.snp_query] = AA_CHANGE_QUERY,
         cnv_region: Optional[base_params.regions] = None,
-        cnv_colorscale: plotly_params.color_continuous_scale = "PuOr_r",
+        cnv_colorscale: plotly_params.color_continuous_scale = cnv_params.colorscale_default,
         cnv_max_coverage_variance: cnv_params.max_coverage_variance = 0.2,
         site_mask: Optional[base_params.site_mask] = None,
         sample_sets: Optional[base_params.sample_sets] = None,


### PR DESCRIPTION
Resolves #559.

I followed bokeh's lead (and @sanjaynagi's hint) and replaced `NaN`s  with `-1`. I have been trying to use `zhoverformat` to have the `z` value show as `NaN` instead of `-1` but I couldn't find a way to make it work.

Here is a picture of what it looks like:
<img width="843" alt="Screenshot 2024-11-27 at 08 19 47" src="https://github.com/user-attachments/assets/16393ea8-7b33-48fe-b6b6-d670a051e246">
