### PR TITLE
Update switcher.json up to v15.0.1

### DIFF
--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -1,9 +1,44 @@
 [
     {
-        "name": "13.0.0",
-        "version": "v13.0.0",
-        "url": "https:///malariagen.github.io/malariagen-data-python/v13.0.0/",
+        "name": "15.0.1",
+        "version": "v15.0.1",
+        "url": "https:///malariagen.github.io/malariagen-data-python/v15.0.1/",
         "preferred": true
+    },
+    {
+        "name": "14.0.0",
+        "version": "v14.0.0",
+        "url": "https:///malariagen.github.io/malariagen-data-python/v14.0.0/",
+    },
+    {
+        "name": "13.5.0",
+        "version": "v13.5.0",
+        "url": "https:///malariagen.github.io/malariagen-data-python/v13.5.0/",
+    },
+    {
+        "name": "13.4.0",
+        "version": "v13.4.0",
+        "url": "https:///malariagen.github.io/malariagen-data-python/v13.4.0/",
+    },
+    {
+        "name": "13.3.0",
+        "version": "v13.3.0",
+        "url": "https:///malariagen.github.io/malariagen-data-python/v13.3.0/",
+    },
+    {
+        "name": "13.2.1",
+        "version": "v13.2.1",
+        "url": "https:///malariagen.github.io/malariagen-data-python/v13.2.0/",
+    },
+    {
+        "name": "13.1.0",
+        "version": "v13.1.0",
+        "url": "https:///malariagen.github.io/malariagen-data-python/v13.1.0/",
+    },
+    {
+        "name": "13.0.4",
+        "version": "v13.0.4",
+        "url": "https:///malariagen.github.io/malariagen-data-python/v13.0.4/",
     },
     {
         "name": "12.0.0",


### PR DESCRIPTION
Add in entries to the docs version switcher up to v15.0.1.

To limit the number of items a bit I've just included one entry for each minor or major version.