### PR TITLE
Updates pf8 default url to s3

### DIFF
--- a/malariagen_data/pf8_config.json
+++ b/malariagen_data/pf8_config.json
@@ -1,5 +1,5 @@
 {
-    "default_url": "s3://pf8-release/",
+    "default_url": "s3://pf8-release/" ,
     "metadata_path": "metadata/Pf8_samples.txt",
     "reference_path": "reference/PlasmoDB-54-Pfalciparum3D7-Genome.zarr/",
     "reference_contigs": [

--- a/malariagen_data/pf8_config.json
+++ b/malariagen_data/pf8_config.json
@@ -1,5 +1,5 @@
 {
-    "default_url": "gs://pf8-release/",
+    "default_url": "s3://pf8-release/",
     "metadata_path": "metadata/Pf8_samples.txt",
     "reference_path": "reference/PlasmoDB-54-Pfalciparum3D7-Genome.zarr/",
     "reference_contigs": [

--- a/tests/integration/test_pf8.py
+++ b/tests/integration/test_pf8.py
@@ -15,7 +15,8 @@ def setup_pf8(url="simplecache::gs://pf8-release/", **storage_kwargs):
 
 @pytest.mark.parametrize(
     "url",
-    [
+    [    
+        "s3://pf8-release/",
         "gs://pf8-release/",
         "gcs://pf8-release/",
         "gs://pf8-release",

--- a/tests/integration/test_pf8.py
+++ b/tests/integration/test_pf8.py
@@ -15,7 +15,7 @@ def setup_pf8(url="simplecache::gs://pf8-release/", **storage_kwargs):
 
 @pytest.mark.parametrize(
     "url",
-    [    
+    [
         "s3://pf8-release/",
         "gs://pf8-release/",
         "gcs://pf8-release/",


### PR DESCRIPTION
Hello, 
Pf8 data objects are currently stored in both Google Cloud Storage (GCS) and Sanger S3. Based on a recent cost analysis, S3 has been identified as the more cost-effective option. As a result, this PR attempts to update Pf8()'s default URL to point to S3.
Cheers, Eyyub