### PR TITLE
Handling absence of terms of use info in `sample_metadata`

### DIFF
--- a/malariagen_data/anoph/sample_metadata.py
+++ b/malariagen_data/anoph/sample_metadata.py
@@ -162,10 +162,12 @@ class AnophelesSampleMetadata(AnophelesBase):
                 df[column] = study_info[column]
 
             # Add terms-of-use columns.
-            terms_of_use_info = self.lookup_terms_of_use_info(sample_set=sample_set)
-            for column in terms_of_use_info:
-                df[column] = terms_of_use_info[column]
-
+            try:
+                terms_of_use_info = self.lookup_terms_of_use_info(sample_set=sample_set)
+                for column in terms_of_use_info:
+                    df[column] = terms_of_use_info[column]
+            except ValueError:
+                pass
             return df
 
         else:


### PR DESCRIPTION
Addresses #766.

I chose to catch the error raised by `lookup_terms_of_use_info` in `sample_metadata` so that, in the absence of terms of use info (e.g., before release of a sample set), the function remains usable. This means that `sample_metadata` no longer raises an error when the terms of use info is missing in the general case but this probably shouldn't be checked by this function. In cases where the check should still take place, `lookup_terms_of_use_info` still raises an error so it shouldn't affect any other function (though I don't think it used anywhere else).