### PR TITLE
feat: add cohort-based downsampling to PCA

### DIFF
--- a/docs/source/Ag3.rst
+++ b/docs/source/Ag3.rst
@@ -141,6 +141,22 @@ Principal components analysis (PCA)
     plot_pca_coords
     plot_pca_coords_3d
 
+.. rubric:: Cohort-based downsampling
+
+The ``pca`` method supports a ``cohorts`` parameter. If provided, samples are grouped by the specified column in the sample metadata, and each group is downsampled to a maximum size equal to ``max_cohort_size``. If ``cohorts`` is not provided, ``max_cohort_size`` applies globally to all selected samples.
+
+**Example:**
+
+.. code-block:: python
+
+    df_pca, evr = ag3.pca(
+        region="3L:15,000,000-16,000,000",
+        sample_sets="AG1000G-BF-A",
+        n_snps=10_000,
+        max_cohort_size=5,  
+        cohorts="country",
+    )
+
 Genetic distance and neighbour-joining trees (NJT)
 --------------------------------------------------
 .. autosummary::

--- a/notebooks/plot_pca.ipynb
+++ b/notebooks/plot_pca.ipynb
@@ -621,6 +621,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "3b533320",
+   "metadata": {},
+   "source": [
+    "## Example: PCA with cohort-based downsampling\n",
+    "\n",
+    "You can use the `cohorts` parameter in the PCA API to downsample each group (e.g., country, location) to a maximum number of samples, specified by `max_cohort_size`. This is useful for balancing representation across groups in your PCA."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc247f54",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_pca, evr = ag3.pca(\n",
+    "    region=\"3L:15,000,000-16,000,000\",\n",
+    "    sample_sets=\"AG1000G-BF-A\",\n",
+    "    n_snps=10_000,\n",
+    "    max_cohort_size=5,  # no more than 5 samples per country\n",
+    "    cohorts=\"country\",\n",
+    ")\n",
+    "df_pca[\"country\"].value_counts()  # verify no country exceeds 5 samples\n",
+    "ag3.plot_pca_coords(df_pca, color=\"country\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "33d788a2-f256-4930-b1e5-b4f31e681a36",


### PR DESCRIPTION
### Add cohort-based downsampling to PCA

This PR introduces a new `cohorts` parameter to the PCA API, enabling users to downsample samples by a specified metadata column (e.g., country, location, admin1_region). When `cohorts` is provided, each group is randomly downsampled to a maximum of `max_cohort_size` samples before PCA is performed.

**Key changes:**
- Added `cohorts` parameter to the PCA API and internal methods.
- Implemented per-group downsampling logic using Pandas.
- Updated docstrings and type hints for clarity.
- Added unit tests to verify correct cohort-based downsampling.
- Updated example notebook and API documentation to demonstrate usage.

#765 