### PR TITLE
Add cohort downsampling support to PCA and update tests

### DIFF
--- a/notebooks/plot_pca.ipynb
+++ b/notebooks/plot_pca.ipynb
@@ -621,9 +621,37 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "f1e8c954",
+   "metadata": {},
+   "source": [
+    "## PCA with cohort downsampling"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33d788a2-f256-4930-b1e5-b4f31e681a36",
+   "id": "e4a484f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_pca_cohorts, evr_cohorts = ag3.pca(\n",
+    "    region=\"3L:15,000,000-16,000,000\",\n",
+    "    sample_sets=\"3.0\",\n",
+    "    n_snps=10_000,\n",
+    "    cohorts=\"country\",\n",
+    "    max_cohort_size=20,\n",
+    ")\n",
+    "ag3.plot_pca_coords(\n",
+    "    df_pca_cohorts,\n",
+    "    color=\"country\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abb2ee83",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
- Introduced `cohorts`, `cohort_size`, `min_cohort_size`, and `max_cohort_size` parameters in the PCA method.
- Updated PCA docstring to reflect new parameters.
- Added example usage for cohort downsampling in the notebook.
- Implemented tests for cohort downsampling functionality, including validation of parameter combinations.