### PR TITLE
Ag3.plot frequencies time series

### DIFF
--- a/malariagen_data/anoph/frq_base.py
+++ b/malariagen_data/anoph/frq_base.py
@@ -385,8 +385,8 @@ class AnophelesFrequencyAnalysis(AnophelesBase):
 
         # Build a long-form dataframe from the dataset.
         dfs = []
-        for cohort_index, cohort in enumerate(df_cohorts.itertuples()):
-            ds_cohort = ds.isel(cohorts=cohort_index)
+        for cohort in df_cohorts.itertuples():
+            ds_cohort = ds.isel(cohorts=cohort.Index)
             df = pd.DataFrame(
                 {
                     "taxon": cohort.taxon,


### PR DESCRIPTION
## Fix `plot_frequencies_time_series` plotting wrong frequencies after filtering (#827)

### Problem

When calling `plot_frequencies_time_series` with `areas` or `taxa` filters, the plot displayed incorrect (typically zero) frequencies instead of the actual values.

For example, filtering to `areas='BF-09', taxa='gambiae'` would show flat zero lines in the plot, despite the underlying dataset containing non-zero frequencies (e.g. L21F=72%, S71P=38%) for that cohort.

### Root Cause

In `frq_base.py`, after filtering `df_cohorts` by `areas`/`taxa`, the loop used `enumerate()` to index back into the original xarray dataset:

```python
# BEFORE (buggy)
for cohort_index, cohort in enumerate(df_cohorts.itertuples()):
    ds_cohort = ds.isel(cohorts=cohort_index)  # re-enumerates from 0 after filtering
```

After filtering, `cohort_index` restarts from `0`, so `ds.isel(cohorts=0)` always reads the first cohort in the **original unfiltered dataset**, not the filtered one. This caused the wrong cohort's frequency values to be plotted.

### Fix

Use `cohort.Index` from `itertuples()`, which preserves the original dataframe index and correctly maps back to the cohort's position in the xarray dataset:

```python
# AFTER (fixed)
for cohort in df_cohorts.itertuples():
    ds_cohort = ds.isel(cohorts=cohort.Index)
```

### Testing

Reproduced the bug and verified the fix with a mock dataset containing 4 cohorts across multiple areas and taxa, where the target cohort (`BF-09/gambiae`) sits at index 2 in the dataset. The buggy version read index 0 and returned zeros; the fixed version correctly returns the expected frequencies.

Closes #827
