### PR TITLE
Add downsampling warning to snp_calls, haplotypes, and phenotype data

### DIFF
--- a/malariagen_data/anoph/hap_data.py
+++ b/malariagen_data/anoph/hap_data.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Optional, Tuple
 
+import warnings
 import dask.array as da
 import numpy as np
 import xarray as xr
@@ -437,6 +438,10 @@ class AnophelesHapData(
             # Handle max cohort size.
             n_samples = ds.sizes["samples"]
             if n_samples > max_cohort_size:
+                warnings.warn(
+                    f"Cohort downsampled from {n_samples} to {max_cohort_size} samples "
+                    f"(random_seed={random_seed})."
+                )
                 rng = np.random.default_rng(seed=random_seed)
                 loc_downsample = rng.choice(
                     n_samples, size=max_cohort_size, replace=False

--- a/malariagen_data/anoph/phenotypes.py
+++ b/malariagen_data/anoph/phenotypes.py
@@ -140,8 +140,14 @@ class AnophelesPhenotypeData:
             if min_cohort_size is not None and group_size < min_cohort_size:
                 continue
             if max_cohort_size is not None and group_size > max_cohort_size:
+                warnings.warn(
+                    f"Cohort downsampled from {group_size} to {max_cohort_size} samples."
+                )
                 group = group.sample(n=max_cohort_size, random_state=42)
             elif cohort_size is not None and group_size > cohort_size:
+                warnings.warn(
+                    f"Cohort downsampled from {group_size} to {cohort_size} samples."
+                )
                 group = group.sample(n=cohort_size, random_state=42)
             elif cohort_size is not None and group_size < cohort_size:
                 continue

--- a/malariagen_data/anoph/snp_data.py
+++ b/malariagen_data/anoph/snp_data.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import warnings
 import allel  # type: ignore
 import bokeh
 import dask.array as da
@@ -1253,6 +1254,10 @@ class AnophelesSnpData(
         if max_cohort_size is not None:
             n_samples = ds.sizes["samples"]
             if n_samples > max_cohort_size:
+                warnings.warn(
+                    f"Cohort downsampled from {n_samples} to {max_cohort_size} samples "
+                    f"(random_seed={random_seed})."
+                )
                 rng = np.random.default_rng(seed=random_seed)
                 loc_downsample = rng.choice(
                     n_samples, size=max_cohort_size, replace=False

--- a/tests/anoph/test_hap_data.py
+++ b/tests/anoph/test_hap_data.py
@@ -539,6 +539,29 @@ def test_haplotypes_with_max_cohort_size_param(
         )
 
 
+def test_haplotypes_downsample_warning(
+    ag3_sim_fixture, ag3_sim_api: AnophelesHapData
+):
+    api = ag3_sim_api
+    fixture = ag3_sim_fixture
+
+    # Fixed parameters.
+    all_sample_sets = api.sample_sets()["sample_set"].to_list()
+    sample_sets = random.choice(all_sample_sets)
+    region = fixture.random_region_str()
+    analysis = api.phasing_analysis_ids[0]
+
+    # Use a very small max_cohort_size to guarantee downsampling.
+    max_cohort_size = 1
+    with pytest.warns(UserWarning, match="Cohort downsampled from"):
+        api.haplotypes(
+            region=region,
+            sample_sets=sample_sets,
+            analysis=analysis,
+            max_cohort_size=max_cohort_size,
+        )
+
+
 # check behaviour when no haplotype data is present within a sample set
 def test_haplotypes_with_empty_calls(ag3_sim_fixture, ag3_sim_api: AnophelesHapData):
     api = ag3_sim_api

--- a/tests/anoph/test_snp_data.py
+++ b/tests/anoph/test_snp_data.py
@@ -906,6 +906,22 @@ def test_snp_calls_with_max_cohort_size_param(fixture, api: AnophelesSnpData):
 
 
 @parametrize_with_cases("fixture,api", cases=".")
+def test_snp_calls_downsample_warning(fixture, api: AnophelesSnpData):
+    # Use a very small max_cohort_size to guarantee downsampling.
+    all_sample_sets = api.sample_sets()["sample_set"].to_list()
+    sample_sets = random.choice(all_sample_sets)
+    region = fixture.random_region_str()
+
+    max_cohort_size = 1
+    with pytest.warns(UserWarning, match="Cohort downsampled from"):
+        api.snp_calls(
+            sample_sets=sample_sets,
+            region=region,
+            max_cohort_size=max_cohort_size,
+        )
+
+
+@parametrize_with_cases("fixture,api", cases=".")
 def test_snp_calls_with_cohort_size_param(fixture, api: AnophelesSnpData):
     # Randomly fix some input parameters.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()


### PR DESCRIPTION
## Summary
- Emits a `UserWarning` when cohort downsampling occurs in `snp_calls()`, `haplotypes()`, and phenotype data methods
- Adds tests verifying the warning is raised

Resolves issue #912

---