### PR TITLE
fix: replace veff TODO placeholder effects

### DIFF
--- a/malariagen_data/veff.py
+++ b/malariagen_data/veff.py
@@ -364,10 +364,8 @@ def _get_within_cds_effect(ann, base_effect, cds, cdss):
             effect = base_effect._replace(effect="CODON_CHANGE", impact="MODERATE")
 
         else:
-            # TODO in-frame complex variation (MNP + INDEL)
-            effect = base_effect._replace(
-                effect="TODO in-frame complex variation (MNP + INDEL)", impact="UNKNOWN"
-            )
+            # in-frame complex variation (MNP + INDEL)
+            effect = base_effect._replace(effect="COMPLEX_CHANGE", impact="MODERATE")
 
     return effect
 
@@ -523,23 +521,16 @@ def _get_within_intron_effect(base_effect, intron):
 
     intron_min_dist = min(intron_5prime_dist, -intron_3prime_dist)
 
-    if len(ref) == 1 and len(alt) == 1:
-        # SNPs
+    if intron_min_dist <= 2:
+        # splice site variation
+        effect = base_effect._replace(effect="SPLICE_CORE", impact="HIGH")
 
-        if intron_min_dist <= 2:
-            # splice site variation
-            effect = base_effect._replace(effect="SPLICE_CORE", impact="HIGH")
-
-        elif intron_min_dist <= 7:
-            # splice site variation
-            effect = base_effect._replace(effect="SPLICE_REGION", impact="MODERATE")
-
-        else:
-            # intron modifier
-            effect = base_effect._replace(effect="INTRONIC", impact="MODIFIER")
+    elif intron_min_dist <= 7:
+        # splice site variation
+        effect = base_effect._replace(effect="SPLICE_REGION", impact="MODERATE")
 
     else:
-        # TODO intronic INDELs and MNPs
-        effect = base_effect._replace(effect="TODO intronic indels and MNPs")
+        # intron modifier
+        effect = base_effect._replace(effect="INTRONIC", impact="MODIFIER")
 
     return effect

--- a/tests/test_veff.py
+++ b/tests/test_veff.py
@@ -1,0 +1,75 @@
+import pytest
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+_veff_path = Path(__file__).resolve().parents[1] / "malariagen_data" / "veff.py"
+_veff_spec = spec_from_file_location("veff_under_test", _veff_path)
+assert _veff_spec is not None and _veff_spec.loader is not None
+veff = module_from_spec(_veff_spec)
+_veff_spec.loader.exec_module(veff)
+
+
+@pytest.mark.parametrize(
+    "ref_start,ref_stop,expected_effect,expected_impact",
+    [
+        (100, 101, "SPLICE_CORE", "HIGH"),
+        (104, 105, "SPLICE_REGION", "MODERATE"),
+        (120, 121, "INTRONIC", "MODIFIER"),
+    ],
+)
+def test_intronic_indel_effects_are_classified(
+    ref_start, ref_stop, expected_effect, expected_impact
+):
+    base_effect = veff.null_effect._replace(
+        ref="AT",
+        alt="A",
+        ref_start=ref_start,
+        ref_stop=ref_stop,
+        strand="+",
+    )
+
+    effect = veff._get_within_intron_effect(base_effect=base_effect, intron=(100, 200))
+
+    assert effect.effect == expected_effect
+    assert effect.impact == expected_impact
+    assert "TODO" not in effect.effect
+
+
+def test_inframe_complex_cds_effect_is_classified(monkeypatch):
+    # We only need to exercise branch logic here; codon details are not under test.
+    monkeypatch.setattr(
+        veff,
+        "_get_aa_change",
+        lambda ann, chrom, pos, ref, alt, cds, cdss: (
+            0,
+            1,
+            0,
+            "ATG",
+            "ATG",
+            1,
+            "M",
+            "M",
+        ),
+    )
+
+    base_effect = veff.null_effect._replace(
+        chrom="2L",
+        pos=100,
+        ref="AT",
+        alt="ATGTA",
+        ref_start=100,
+        ref_stop=101,
+        strand="+",
+    )
+
+    effect = veff._get_within_cds_effect(
+        ann=None,
+        base_effect=base_effect,
+        cds=None,
+        cdss=[],
+    )
+
+    assert effect.effect == "COMPLEX_CHANGE"
+    assert effect.impact == "MODERATE"
+    assert "TODO" not in effect.effect


### PR DESCRIPTION
## Summary
- replace TODO placeholder effect strings in `veff.py` with real classifications
- classify in-frame complex CDS variation as `COMPLEX_CHANGE` with `MODERATE` impact
- classify intronic non-SNP variants (INDEL/MNP) by splice distance, consistent with SNP intronic handling
- add regression tests to ensure TODO strings never leak into output effect values

## Changes
- `malariagen_data/veff.py`
  - replaced `"TODO in-frame complex variation (MNP + INDEL)"` with `"COMPLEX_CHANGE"` / `"MODERATE"`
  - removed TODO fallback for intronic INDEL/MNP and now return:
    - `SPLICE_CORE` (`HIGH`) when distance <= 2
    - `SPLICE_REGION` (`MODERATE`) when distance <= 7
    - `INTRONIC` (`MODIFIER`) otherwise
- `tests/test_veff.py`
  - added tests covering intronic INDEL classification
  - added test covering in-frame complex CDS classification

## Validation
- ran: `pytest -q tests/test_veff.py -vv`
- result: `4 passed`

Fixes #916