### PR TITLE
Add support for Python 3.13 and NumPy 2.1, drop Python 3.10

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "pip"
 
       - name: Install package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.10"]
-        numpy-version: ["numpy==1.26.4"]
+        python-version: ["3.11", "3.12", "3.13"]
+        numpy-version: ["numpy==1.26.4", "numpy>=2.1"]
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -10,22 +10,6 @@ package index (PyPI) and can be installed via `pip`, e.g.:
 ```bash
 pip install malariagen-data
 ```
-## Quick Start
-
-Once installed, you can begin accessing MalariaGEN datasets directly
-from Python.
-
-For example, to work with the Pf8 dataset:
-
-```python
-import malariagen_data
-
-# Instantiate dataset
-pf8 = malariagen_data.Pf8()
-
-# Load sample metadata
-df = pf8.sample_metadata()
-print(df.head())
 
 ## Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,9 @@ authors = [
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
-numpy = "==1.26.4"
-numba = ">=0.60.0"
+python = ">=3.11,<3.14"
+numpy = ">=1.26.4"
+numba = ">=0.61"
 llvmlite = "*"
 scipy = "*"
 pandas = "*"


### PR DESCRIPTION
closes #681 

Now that Numba 0.61 was released in January 2025 (resolving the blocker numba/numba#9777), this PR implements the changes requested in the issue.

## Changes:

- pyproject.toml: loosen numpy pin from ==1.26.4 to >=1.26.4, python from >=3.10,<3.13 to >=3.11,<3.14
- .github/workflows/tests.yml: expand CI matrix to test Python 3.11, 3.12, 3.13 against both NumPy 1.26.4 and NumPy 2.1