### PR TITLE
Add dataset-return options for SNP counts/diplotypes and remove duplicates

### DIFF
--- a/malariagen_data/anoph/base_params.py
+++ b/malariagen_data/anoph/base_params.py
@@ -326,3 +326,12 @@ snp_query: TypeAlias = Annotated[
     to select SNPs to be included
     """,
 ]
+
+return_dataset: TypeAlias = Annotated[
+    bool,
+    """
+    If True, return an xarray Dataset containing computed results as
+    additional data variables. If False (default), return the legacy
+    format (numpy array or tuple) for backward compatibility.
+    """,
+]

--- a/malariagen_data/anoph/distance.py
+++ b/malariagen_data/anoph/distance.py
@@ -195,7 +195,7 @@ class AnophelesDistanceAnalysis(AnophelesSnpData):
         max_missing_an,
     ):
         # Compute diplotypes.
-        gn, samples = self.biallelic_diplotypes(
+        ds = self.biallelic_diplotypes(
             region=region,
             sample_sets=sample_sets,
             sample_indices=sample_indices,
@@ -211,7 +211,10 @@ class AnophelesDistanceAnalysis(AnophelesSnpData):
             min_minor_ac=min_minor_ac,
             n_snps=n_snps,
             thin_offset=thin_offset,
+            return_dataset=True,
         )
+        gn = ds["call_diplotype"].values
+        samples = ds["sample_id"].values.astype("U")
 
         # Record number of SNPs used.
         n_snps = gn.shape[0]

--- a/malariagen_data/anoph/distance.py
+++ b/malariagen_data/anoph/distance.py
@@ -1,5 +1,5 @@
 # Standard library imports.
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 import math
 
 # Third-party library imports.
@@ -86,7 +86,12 @@ class AnophelesDistanceAnalysis(AnophelesSnpData):
         summary="""
             Compute pairwise distances between samples using biallelic SNP genotypes.
         """,
-        returns=("dist", "samples", "n_snps_used"),
+        returns="""
+            If `return_dataset` is False (default), return a tuple
+            `(dist, samples, n_snps_used)`. If `return_dataset` is True,
+            return an xarray Dataset with `dist`, `sample_id`, and
+            `n_snps_used` as variables/coordinates.
+        """,
     )
     def biallelic_diplotype_pairwise_distances(
         self,
@@ -108,22 +113,14 @@ class AnophelesDistanceAnalysis(AnophelesSnpData):
         random_seed: base_params.random_seed = 42,
         inline_array: base_params.inline_array = base_params.inline_array_default,
         chunks: base_params.chunks = base_params.native_chunks,
-    ) -> Tuple[
-        distance_params.dist, distance_params.samples, distance_params.n_snps_used
-    ]:
-        # Change this name if you ever change the behaviour of this function, to
-        # invalidate any previously cached data.
+        return_dataset: base_params.return_dataset = False,
+    ) -> Any:
         name = "biallelic_diplotype_pairwise_distances"
 
-        # Check that either sample_query xor sample_indices are provided.
         base_params._validate_sample_selection_params(
             sample_query=sample_query, sample_indices=sample_indices
         )
 
-        ## Normalize params for consistent hash value.
-
-        # Note: `_prep_sample_selection_cache_params` converts `sample_query` and `sample_query_options` into `sample_indices`.
-        # So `sample_query` and `sample_query_options` should not be used beyond this point. (`sample_indices` should be used instead.)
         (
             sample_sets_prepped,
             sample_indices_prepped,
@@ -158,7 +155,6 @@ class AnophelesDistanceAnalysis(AnophelesSnpData):
             max_missing_an=max_missing_an,
         )
 
-        # Try to retrieve results from the cache.
         try:
             results = self.results_cache_get(name=name, params=params)
 
@@ -168,10 +164,24 @@ class AnophelesDistanceAnalysis(AnophelesSnpData):
             )
             self.results_cache_set(name=name, params=params, results=results)
 
-        # Unpack results.
         dist: np.ndarray = results["dist"]
         samples: np.ndarray = results["samples"]
-        n_snps_used: int = int(results["n_snps"][()])  # ensure scalar
+        n_snps_used: int = int(results["n_snps"][()])
+
+        if return_dataset:
+            import xarray as xr
+            from scipy.spatial.distance import squareform
+            dist_square = squareform(dist)
+            ds = xr.Dataset(
+                data_vars={
+                    "dist": (("sample_x", "sample_y"), dist_square),
+                },
+                coords={
+                    "sample_id": ("sample_x", samples),
+                },
+                attrs={"n_snps_used": n_snps_used},
+            )
+            return ds
 
         return dist, samples, n_snps_used
 

--- a/malariagen_data/anoph/distance.py
+++ b/malariagen_data/anoph/distance.py
@@ -171,6 +171,7 @@ class AnophelesDistanceAnalysis(AnophelesSnpData):
         if return_dataset:
             import xarray as xr
             from scipy.spatial.distance import squareform
+
             dist_square = squareform(dist)
             ds = xr.Dataset(
                 data_vars={

--- a/malariagen_data/anoph/distance.py
+++ b/malariagen_data/anoph/distance.py
@@ -119,10 +119,15 @@ class AnophelesDistanceAnalysis(AnophelesSnpData):
         # invalidate any previously cached data.
         name = "biallelic_diplotype_pairwise_distances"
 
+        # Check that either sample_query xor sample_indices are provided.
         base_params._validate_sample_selection_params(
             sample_query=sample_query, sample_indices=sample_indices
         )
 
+        ## Normalize params for consistent hash value.
+
+        # Note: `_prep_sample_selection_cache_params` converts `sample_query` and `sample_query_options` into `sample_indices`.
+        # So `sample_query` and `sample_query_options` should not be used beyond this point. (`sample_indices` should be used instead.)
         (
             sample_sets_prepped,
             sample_indices_prepped,

--- a/malariagen_data/anoph/distance.py
+++ b/malariagen_data/anoph/distance.py
@@ -115,6 +115,8 @@ class AnophelesDistanceAnalysis(AnophelesSnpData):
         chunks: base_params.chunks = base_params.native_chunks,
         return_dataset: base_params.return_dataset = False,
     ) -> Any:
+        # Change this name if you ever change the behaviour of this function, to
+        # invalidate any previously cached data.
         name = "biallelic_diplotype_pairwise_distances"
 
         base_params._validate_sample_selection_params(
@@ -155,6 +157,7 @@ class AnophelesDistanceAnalysis(AnophelesSnpData):
             max_missing_an=max_missing_an,
         )
 
+        # Try to retrieve results from the cache.
         try:
             results = self.results_cache_get(name=name, params=params)
 
@@ -164,9 +167,10 @@ class AnophelesDistanceAnalysis(AnophelesSnpData):
             )
             self.results_cache_set(name=name, params=params, results=results)
 
+        # Unpack results.
         dist: np.ndarray = results["dist"]
         samples: np.ndarray = results["samples"]
-        n_snps_used: int = int(results["n_snps"][()])
+        n_snps_used: int = int(results["n_snps"][()])  # ensure scalar
 
         if return_dataset:
             import xarray as xr

--- a/malariagen_data/anoph/hapclust.py
+++ b/malariagen_data/anoph/hapclust.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 import allel  # type: ignore
 import numpy as np

--- a/malariagen_data/anoph/hapclust.py
+++ b/malariagen_data/anoph/hapclust.py
@@ -262,12 +262,15 @@ class AnophelesHapClustAnalysis(
             from scipy.spatial.distance import squareform
 
             dist_square = squareform(dist)
+            # Each phased sample contributes 2 haplotypes; create
+            # haplotype-level labels to match the distance matrix.
+            hap_labels = np.repeat(phased_samples, 2)
             ds = xr.Dataset(
                 data_vars={
                     "dist": (("sample_x", "sample_y"), dist_square),
                 },
                 coords={
-                    "sample_id": ("sample_x", phased_samples),
+                    "sample_id": ("sample_x", hap_labels),
                 },
                 attrs={"n_snps": n_snps},
             )

--- a/malariagen_data/anoph/hapclust.py
+++ b/malariagen_data/anoph/hapclust.py
@@ -260,6 +260,7 @@ class AnophelesHapClustAnalysis(
         if return_dataset:
             import xarray as xr
             from scipy.spatial.distance import squareform
+
             dist_square = squareform(dist)
             ds = xr.Dataset(
                 data_vars={

--- a/malariagen_data/anoph/hapclust.py
+++ b/malariagen_data/anoph/hapclust.py
@@ -225,8 +225,11 @@ class AnophelesHapClustAnalysis(
         inline_array: base_params.inline_array = base_params.inline_array_default,
         return_dataset: base_params.return_dataset = False,
     ) -> Any:
+        # Change this name if you ever change the behaviour of this function, to
+        # invalidate any previously cached data.
         name = "haplotype_pairwise_distances"
 
+        # Normalize params for consistent hash value.
         sample_sets_prepped = self._prep_sample_sets_param(sample_sets=sample_sets)
         del sample_sets
         sample_query_prepped = self._prep_sample_query_param(sample_query=sample_query)
@@ -244,6 +247,7 @@ class AnophelesHapClustAnalysis(
             random_seed=random_seed,
         )
 
+        # Try to retrieve results from the cache.
         try:
             results = self.results_cache_get(name=name, params=params)
 
@@ -253,9 +257,10 @@ class AnophelesHapClustAnalysis(
             )
             self.results_cache_set(name=name, params=params, results=results)
 
+        # Unpack results.
         dist: np.ndarray = results["dist"]
         phased_samples: np.ndarray = results["phased_samples"]
-        n_snps: int = int(results["n_snps"][()])
+        n_snps: int = int(results["n_snps"][()])  # ensure scalar
 
         if return_dataset:
             import xarray as xr

--- a/malariagen_data/anoph/hapclust.py
+++ b/malariagen_data/anoph/hapclust.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 import allel  # type: ignore
 import numpy as np
@@ -204,11 +204,12 @@ class AnophelesHapClustAnalysis(
         summary="""
             Compute pairwise distances between haplotypes.
         """,
-        returns=dict(
-            dist="Pairwise distance.",
-            phased_samples="Sample identifiers for haplotypes.",
-            n_snps="Number of SNPs used.",
-        ),
+        returns="""
+            If `return_dataset` is False (default), return a tuple
+            `(dist, phased_samples, n_snps)`. If `return_dataset` is True,
+            return an xarray Dataset with `dist`, `sample_id`, and
+            `n_snps` as variables/attributes.
+        """,
     )
     def haplotype_pairwise_distances(
         self,
@@ -222,12 +223,10 @@ class AnophelesHapClustAnalysis(
         random_seed: base_params.random_seed = 42,
         chunks: base_params.chunks = base_params.native_chunks,
         inline_array: base_params.inline_array = base_params.inline_array_default,
-    ) -> Tuple[np.ndarray, np.ndarray, int]:
-        # Change this name if you ever change the behaviour of this function, to
-        # invalidate any previously cached data.
+        return_dataset: base_params.return_dataset = False,
+    ) -> Any:
         name = "haplotype_pairwise_distances"
 
-        # Normalize params for consistent hash value.
         sample_sets_prepped = self._prep_sample_sets_param(sample_sets=sample_sets)
         del sample_sets
         sample_query_prepped = self._prep_sample_query_param(sample_query=sample_query)
@@ -245,7 +244,6 @@ class AnophelesHapClustAnalysis(
             random_seed=random_seed,
         )
 
-        # Try to retrieve results from the cache.
         try:
             results = self.results_cache_get(name=name, params=params)
 
@@ -255,10 +253,24 @@ class AnophelesHapClustAnalysis(
             )
             self.results_cache_set(name=name, params=params, results=results)
 
-        # Unpack results")
         dist: np.ndarray = results["dist"]
         phased_samples: np.ndarray = results["phased_samples"]
-        n_snps: int = int(results["n_snps"][()])  # ensure scalar
+        n_snps: int = int(results["n_snps"][()])
+
+        if return_dataset:
+            import xarray as xr
+            from scipy.spatial.distance import squareform
+            dist_square = squareform(dist)
+            ds = xr.Dataset(
+                data_vars={
+                    "dist": (("sample_x", "sample_y"), dist_square),
+                },
+                coords={
+                    "sample_id": ("sample_x", phased_samples),
+                },
+                attrs={"n_snps": n_snps},
+            )
+            return ds
 
         return dist, phased_samples, n_snps
 

--- a/malariagen_data/anoph/pca.py
+++ b/malariagen_data/anoph/pca.py
@@ -207,7 +207,7 @@ class AnophelesPca(
         inline_array,
     ):
         # Load diplotypes.
-        gn, samples = self.biallelic_diplotypes(
+        ds_diplotypes = self.biallelic_diplotypes(
             region=region,
             n_snps=n_snps,
             thin_offset=thin_offset,
@@ -223,7 +223,10 @@ class AnophelesPca(
             random_seed=random_seed,
             chunks=chunks,
             inline_array=inline_array,
+            return_dataset=True,
         )
+        gn = ds_diplotypes["call_diplotype"].values
+        samples = ds_diplotypes["sample_id"].values.astype("U")
 
         with self._spinner(desc="Compute PCA"):
             # Exclude any samples prior to computing PCA.

--- a/malariagen_data/anoph/snp_data.py
+++ b/malariagen_data/anoph/snp_data.py
@@ -1452,6 +1452,13 @@ class AnophelesSnpData(
             Compute SNP allele counts. This returns the number of times each
             SNP allele was observed in the selected samples.
         """,
+        parameters=dict(
+            return_dataset="""
+                If True, return an xarray dataset containing SNP calls with
+                `variant_allele_count` added as an extra data variable. If False
+                (default), return a numpy array of allele counts.
+            """
+        ),
         returns="""
             A numpy array of shape (n_variants, 4), where the first column has
             the reference allele (0) counts, the second column has the first
@@ -1481,7 +1488,26 @@ class AnophelesSnpData(
         random_seed: base_params.random_seed = 42,
         inline_array: base_params.inline_array = base_params.inline_array_default,
         chunks: base_params.chunks = base_params.native_chunks,
-    ) -> np.ndarray:
+        return_dataset: bool = False,
+    ) -> Any:
+        if return_dataset:
+            ds = self._snp_calls_with_allele_counts(
+                region=region,
+                sample_sets=sample_sets,
+                sample_query=sample_query,
+                sample_query_options=sample_query_options,
+                sample_indices=sample_indices,
+                site_mask=site_mask,
+                site_class=site_class,
+                cohort_size=cohort_size,
+                min_cohort_size=min_cohort_size,
+                max_cohort_size=max_cohort_size,
+                random_seed=random_seed,
+                inline_array=inline_array,
+                chunks=chunks,
+            )
+            return ds
+
         # Change this name if you ever change the behaviour of this function,
         # to invalidate any previously cached data.
         name = "snp_allele_counts_v2"
@@ -1554,6 +1580,52 @@ class AnophelesSnpData(
 
         ac = results["ac"]
         return ac
+
+    def _snp_calls_with_allele_counts(
+        self,
+        *,
+        region,
+        sample_sets,
+        sample_query,
+        sample_query_options,
+        sample_indices,
+        site_mask,
+        site_class,
+        cohort_size,
+        min_cohort_size,
+        max_cohort_size,
+        random_seed,
+        inline_array,
+        chunks,
+    ) -> xr.Dataset:
+        ds = self.snp_calls(
+            region=region,
+            sample_sets=sample_sets,
+            sample_query=sample_query,
+            sample_query_options=sample_query_options,
+            sample_indices=sample_indices,
+            site_mask=site_mask,
+            site_class=site_class,
+            cohort_size=cohort_size,
+            min_cohort_size=min_cohort_size,
+            max_cohort_size=max_cohort_size,
+            random_seed=random_seed,
+            inline_array=inline_array,
+            chunks=chunks,
+        )
+
+        gt = allel.GenotypeDaskArray(ds["call_genotype"].data)
+        ac = gt.count_alleles(max_allele=3)
+        with self._dask_progress(desc="Compute SNP allele counts"):
+            ac = ac.compute().values
+
+        ds = ds.assign(
+            variant_allele_count=(
+                ds["variant_allele"].dims,
+                ac,
+            )
+        )
+        return ds
 
     @_check_types
     @doc(
@@ -1897,8 +1969,8 @@ class AnophelesSnpData(
             sample_query=sample_query, sample_indices=sample_indices
         )
 
-        # Perform an allele count.
-        ac = self.snp_allele_counts(
+        # Access SNP calls with allele counts in a single pass.
+        ds = self._snp_calls_with_allele_counts(
             region=region,
             sample_sets=sample_sets,
             sample_query=sample_query,
@@ -1913,6 +1985,7 @@ class AnophelesSnpData(
             inline_array=inline_array,
             chunks=chunks,
         )
+        ac = ds["variant_allele_count"].values
 
         # Locate biallelic SNPs.
         loc_bi = allel.AlleleCountsArray(ac).is_biallelic()
@@ -1920,23 +1993,6 @@ class AnophelesSnpData(
         # Remap alleles to squeeze out unobserved alleles.
         ac_bi = ac[loc_bi]
         allele_mapping = _trim_alleles(ac_bi)
-
-        # Set up SNP calls.
-        ds = self.snp_calls(
-            region=region,
-            sample_sets=sample_sets,
-            sample_query=sample_query,
-            sample_query_options=sample_query_options,
-            sample_indices=sample_indices,
-            site_mask=site_mask,
-            site_class=site_class,
-            cohort_size=cohort_size,
-            min_cohort_size=min_cohort_size,
-            max_cohort_size=max_cohort_size,
-            random_seed=random_seed,
-            inline_array=inline_array,
-            chunks=chunks,
-        )
 
         with self._spinner("Prepare biallelic SNP calls"):
             # Subset to biallelic sites.
@@ -2032,13 +2088,22 @@ class AnophelesSnpData(
     @_check_types
     @doc(
         summary="Load biallelic SNP genotypes.",
-        returns=dict(
-            gn="""
-                An array of shape (variants, samples) where each value counts the
-                number of alternate alleles per genotype call.
-            """,
-            samples="Sample identifiers.",
+        parameters=dict(
+            return_dataset="""
+                If True, return an xarray dataset with `call_diplotype` plus
+                `sample_id`, `variant_position`, and `variant_contig`. If False
+                (default), return a tuple `(gn, samples)` for backward
+                compatibility.
+            """
         ),
+        returns="""
+            If `return_dataset` is False (default), return `(gn, samples)`, where
+            `gn` is an array of shape `(variants, samples)` counting alternate
+            alleles per genotype call and `samples` contains sample identifiers.
+            If `return_dataset` is True, return a dataset containing
+            `call_diplotype` with dimensions `(variants, samples)`, plus
+            `sample_id`, `variant_position`, and `variant_contig`.
+        """,
     )
     def biallelic_diplotypes(
         self,
@@ -2059,7 +2124,8 @@ class AnophelesSnpData(
         thin_offset: base_params.thin_offset = 0,
         inline_array: base_params.inline_array = base_params.inline_array_default,
         chunks: base_params.chunks = base_params.native_chunks,
-    ) -> Tuple[np.ndarray, np.ndarray]:
+        return_dataset: bool = False,
+    ) -> Any:
         # Change this name if you ever change the behaviour of this function, to
         # invalidate any previously cached data.
         name = "biallelic_diplotypes_v2"
@@ -2147,6 +2213,22 @@ class AnophelesSnpData(
         gn = results["gn"]
         samples = results["samples"]
 
+        if return_dataset:
+            ds = xr.Dataset(
+                coords={
+                    "sample_id": ("samples", samples),
+                    "variant_position": ("variants", results["variant_position"]),
+                    "variant_contig": ("variants", results["variant_contig"]),
+                },
+                data_vars={
+                    "call_diplotype": (
+                        ("variants", "samples"),
+                        gn,
+                    )
+                },
+            )
+            return ds
+
         return gn, samples
 
     def _biallelic_diplotypes(
@@ -2193,6 +2275,8 @@ class AnophelesSnpData(
 
         # Load sample IDs
         samples = ds["sample_id"].values.astype("U")
+        variant_position = ds["variant_position"].values
+        variant_contig = ds["variant_contig"].values
 
         # Compute diplotypes as the number of alt alleles per genotype call.
         # with missing calls coded as -127.
@@ -2203,4 +2287,9 @@ class AnophelesSnpData(
         missing = np.all(ds["call_genotype"].values == -1, axis=2)
         gn[missing] = -127
 
-        return dict(samples=samples, gn=gn)
+        return dict(
+            samples=samples,
+            gn=gn,
+            variant_position=variant_position,
+            variant_contig=variant_contig,
+        )

--- a/malariagen_data/anoph/snp_data.py
+++ b/malariagen_data/anoph/snp_data.py
@@ -1570,8 +1570,6 @@ class AnophelesSnpData(
 
         return ac
 
-
-
     @_check_types
     @doc(
         summary="""

--- a/malariagen_data/anoph/snp_data.py
+++ b/malariagen_data/anoph/snp_data.py
@@ -1435,13 +1435,11 @@ class AnophelesSnpData(
         )
         gt = ds_snps["call_genotype"]
 
-        # Set up and run allele counts computation.
         gt = allel.GenotypeDaskArray(gt.data)
         ac = gt.count_alleles(max_allele=3)
         with self._dask_progress(desc="Compute SNP allele counts"):
             ac = ac.compute()
 
-        # Return plain numpy array.
         results = dict(ac=ac.values)
 
         return results
@@ -1452,19 +1450,12 @@ class AnophelesSnpData(
             Compute SNP allele counts. This returns the number of times each
             SNP allele was observed in the selected samples.
         """,
-        parameters=dict(
-            return_dataset="""
-                If True, return an xarray dataset containing SNP calls with
-                `variant_allele_count` added as an extra data variable. If False
-                (default), return a numpy array of allele counts.
-            """
-        ),
         returns="""
-            A numpy array of shape (n_variants, 4), where the first column has
-            the reference allele (0) counts, the second column has the first
-            alternate allele (1) counts, the third column has the second
-            alternate allele (2) counts, and the fourth column has the third
-            alternate allele (3) counts.
+            If `return_dataset` is False (default), a numpy array of shape
+            (n_variants, 4) where columns correspond to allele counts for the
+            reference and three alternate alleles. If `return_dataset` is True,
+            an xarray Dataset containing SNP calls with `variant_allele_count`
+            added as an extra data variable.
         """,
         notes="""
             This computation may take some time to run, depending on your
@@ -1488,39 +1479,14 @@ class AnophelesSnpData(
         random_seed: base_params.random_seed = 42,
         inline_array: base_params.inline_array = base_params.inline_array_default,
         chunks: base_params.chunks = base_params.native_chunks,
-        return_dataset: bool = False,
+        return_dataset: base_params.return_dataset = False,
     ) -> Any:
-        if return_dataset:
-            ds = self._snp_calls_with_allele_counts(
-                region=region,
-                sample_sets=sample_sets,
-                sample_query=sample_query,
-                sample_query_options=sample_query_options,
-                sample_indices=sample_indices,
-                site_mask=site_mask,
-                site_class=site_class,
-                cohort_size=cohort_size,
-                min_cohort_size=min_cohort_size,
-                max_cohort_size=max_cohort_size,
-                random_seed=random_seed,
-                inline_array=inline_array,
-                chunks=chunks,
-            )
-            return ds
-
-        # Change this name if you ever change the behaviour of this function,
-        # to invalidate any previously cached data.
         name = "snp_allele_counts_v2"
 
-        # Check that either sample_query xor sample_indices are provided.
         base_params._validate_sample_selection_params(
             sample_query=sample_query, sample_indices=sample_indices
         )
 
-        ## Normalize params for consistent hash value.
-
-        # Note: `_prep_sample_selection_cache_params` converts `sample_query` and `sample_query_options` into `sample_indices`.
-        # So `sample_query` and `sample_query_options` should not be used beyond this point. (`sample_indices` should be used instead.)
         (
             sample_sets_prepped,
             sample_indices_prepped,
@@ -1579,53 +1545,32 @@ class AnophelesSnpData(
             self.results_cache_set(name=name, params=params, results=results)
 
         ac = results["ac"]
+
+        if return_dataset:
+            ds = self.snp_calls(
+                region=params["region"],
+                sample_sets=params["sample_sets"],
+                sample_indices=params["sample_indices"],
+                site_mask=params["site_mask"],
+                site_class=site_class,
+                cohort_size=cohort_size,
+                min_cohort_size=min_cohort_size,
+                max_cohort_size=max_cohort_size,
+                random_seed=random_seed,
+                inline_array=inline_array,
+                chunks=chunks,
+            )
+            ds = ds.assign(
+                variant_allele_count=(
+                    ds["variant_allele"].dims,
+                    ac,
+                )
+            )
+            return ds
+
         return ac
 
-    def _snp_calls_with_allele_counts(
-        self,
-        *,
-        region,
-        sample_sets,
-        sample_query,
-        sample_query_options,
-        sample_indices,
-        site_mask,
-        site_class,
-        cohort_size,
-        min_cohort_size,
-        max_cohort_size,
-        random_seed,
-        inline_array,
-        chunks,
-    ) -> xr.Dataset:
-        ds = self.snp_calls(
-            region=region,
-            sample_sets=sample_sets,
-            sample_query=sample_query,
-            sample_query_options=sample_query_options,
-            sample_indices=sample_indices,
-            site_mask=site_mask,
-            site_class=site_class,
-            cohort_size=cohort_size,
-            min_cohort_size=min_cohort_size,
-            max_cohort_size=max_cohort_size,
-            random_seed=random_seed,
-            inline_array=inline_array,
-            chunks=chunks,
-        )
 
-        gt = allel.GenotypeDaskArray(ds["call_genotype"].data)
-        ac = gt.count_alleles(max_allele=3)
-        with self._dask_progress(desc="Compute SNP allele counts"):
-            ac = ac.compute().values
-
-        ds = ds.assign(
-            variant_allele_count=(
-                ds["variant_allele"].dims,
-                ac,
-            )
-        )
-        return ds
 
     @_check_types
     @doc(
@@ -1964,13 +1909,11 @@ class AnophelesSnpData(
         n_snps: Optional[base_params.n_snps] = None,
         thin_offset: base_params.thin_offset = 0,
     ) -> xr.Dataset:
-        # Check that either sample_query xor sample_indices are provided.
         base_params._validate_sample_selection_params(
             sample_query=sample_query, sample_indices=sample_indices
         )
 
-        # Access SNP calls with allele counts in a single pass.
-        ds = self._snp_calls_with_allele_counts(
+        ds = self.snp_allele_counts(
             region=region,
             sample_sets=sample_sets,
             sample_query=sample_query,
@@ -1984,6 +1927,7 @@ class AnophelesSnpData(
             random_seed=random_seed,
             inline_array=inline_array,
             chunks=chunks,
+            return_dataset=True,
         )
         ac = ds["variant_allele_count"].values
 
@@ -2088,14 +2032,6 @@ class AnophelesSnpData(
     @_check_types
     @doc(
         summary="Load biallelic SNP genotypes.",
-        parameters=dict(
-            return_dataset="""
-                If True, return an xarray dataset with `call_diplotype` plus
-                `sample_id`, `variant_position`, and `variant_contig`. If False
-                (default), return a tuple `(gn, samples)` for backward
-                compatibility.
-            """
-        ),
         returns="""
             If `return_dataset` is False (default), return `(gn, samples)`, where
             `gn` is an array of shape `(variants, samples)` counting alternate
@@ -2124,11 +2060,9 @@ class AnophelesSnpData(
         thin_offset: base_params.thin_offset = 0,
         inline_array: base_params.inline_array = base_params.inline_array_default,
         chunks: base_params.chunks = base_params.native_chunks,
-        return_dataset: bool = False,
+        return_dataset: base_params.return_dataset = False,
     ) -> Any:
-        # Change this name if you ever change the behaviour of this function, to
-        # invalidate any previously cached data.
-        name = "biallelic_diplotypes_v2"
+        name = "biallelic_diplotypes_v3"
 
         # Check that either sample_query xor sample_indices are provided.
         base_params._validate_sample_selection_params(
@@ -2185,12 +2119,11 @@ class AnophelesSnpData(
             max_missing_an=max_missing_an,
         )
 
-        # Try to retrieve results from the cache.
         try:
             results = self.results_cache_get(name=name, params=params)
 
         except CacheMiss:
-            results = self._biallelic_diplotypes(
+            ds = self._biallelic_diplotypes(
                 inline_array=inline_array,
                 chunks=chunks,
                 region=prepared_region,
@@ -2207,9 +2140,14 @@ class AnophelesSnpData(
                 min_minor_ac=min_minor_ac,
                 max_missing_an=max_missing_an,
             )
+            results = dict(
+                gn=ds["call_diplotype"].values,
+                samples=ds["sample_id"].values,
+                variant_position=ds["variant_position"].values,
+                variant_contig=ds["variant_contig"].values,
+            )
             self.results_cache_set(name=name, params=params, results=results)
 
-        # Unpack results.
         gn = results["gn"]
         samples = results["samples"]
 
@@ -2273,23 +2211,27 @@ class AnophelesSnpData(
             chunks=chunks,
         )
 
-        # Load sample IDs
         samples = ds["sample_id"].values.astype("U")
         variant_position = ds["variant_position"].values
         variant_contig = ds["variant_contig"].values
 
-        # Compute diplotypes as the number of alt alleles per genotype call.
-        # with missing calls coded as -127.
         gt = allel.GenotypeDaskArray(ds["call_genotype"].data)
         with self._dask_progress(desc="Compute biallelic diplotypes"):
             gn = gt.to_n_ref().compute()
-        # Code missing calls as -127.
         missing = np.all(ds["call_genotype"].values == -1, axis=2)
         gn[missing] = -127
 
-        return dict(
-            samples=samples,
-            gn=gn,
-            variant_position=variant_position,
-            variant_contig=variant_contig,
+        ds_out = xr.Dataset(
+            coords={
+                "sample_id": ("samples", samples),
+                "variant_position": ("variants", variant_position),
+                "variant_contig": ("variants", variant_contig),
+            },
+            data_vars={
+                "call_diplotype": (
+                    ("variants", "samples"),
+                    gn,
+                )
+            },
         )
+        return ds_out

--- a/malariagen_data/anoph/snp_data.py
+++ b/malariagen_data/anoph/snp_data.py
@@ -1435,6 +1435,7 @@ class AnophelesSnpData(
         )
         gt = ds_snps["call_genotype"]
 
+        # Set up and run allele counts computation.
         gt = allel.GenotypeDaskArray(gt.data)
         ac = gt.count_alleles(max_allele=3)
         with self._dask_progress(desc="Compute SNP allele counts"):
@@ -1493,10 +1494,15 @@ class AnophelesSnpData(
         # enabling Dataset reconstruction without extra snp_calls().
         name = "snp_allele_counts_v3"
 
+        # Check that either sample_query xor sample_indices are provided.
         base_params._validate_sample_selection_params(
             sample_query=sample_query, sample_indices=sample_indices
         )
 
+        ## Normalize params for consistent hash value.
+
+        # Note: `_prep_sample_selection_cache_params` converts `sample_query` and `sample_query_options` into `sample_indices`.
+        # So `sample_query` and `sample_query_options` should not be used beyond this point. (`sample_indices` should be used instead.)
         (
             sample_sets_prepped,
             sample_indices_prepped,
@@ -2095,6 +2101,8 @@ class AnophelesSnpData(
         chunks: base_params.chunks = base_params.native_chunks,
         return_dataset: base_params.return_dataset = False,
     ) -> Any:
+        # Change this name if you ever change the behaviour of this function, to
+        # invalidate any previously cached data.
         name = "biallelic_diplotypes_v3"
 
         # Check that either sample_query xor sample_indices are provided.
@@ -2152,6 +2160,7 @@ class AnophelesSnpData(
             max_missing_an=max_missing_an,
         )
 
+        # Try to retrieve results from the cache.
         try:
             results = self.results_cache_get(name=name, params=params)
 
@@ -2181,6 +2190,7 @@ class AnophelesSnpData(
             )
             self.results_cache_set(name=name, params=params, results=results)
 
+        # Unpack results.
         gn = results["gn"]
         samples = results["samples"]
 
@@ -2244,10 +2254,13 @@ class AnophelesSnpData(
             chunks=chunks,
         )
 
+        # Load sample IDs.
         samples = ds["sample_id"].values.astype("U")
         variant_position = ds["variant_position"].values
         variant_contig = ds["variant_contig"].values
 
+        # Compute diplotypes as the number of all alleles per genotype call,
+        # with missing calls coded as -127.
         gt = allel.GenotypeDaskArray(ds["call_genotype"].data)
         with self._dask_progress(desc="Compute biallelic diplotypes"):
             gn = gt.to_n_ref().compute()

--- a/malariagen_data/anoph/snp_data.py
+++ b/malariagen_data/anoph/snp_data.py
@@ -1922,6 +1922,7 @@ class AnophelesSnpData(
         n_snps: Optional[base_params.n_snps] = None,
         thin_offset: base_params.thin_offset = 0,
     ) -> xr.Dataset:
+        # Check that either sample_query xor sample_indices are provided.
         base_params._validate_sample_selection_params(
             sample_query=sample_query, sample_indices=sample_indices
         )

--- a/malariagen_data/anoph/snp_data.py
+++ b/malariagen_data/anoph/snp_data.py
@@ -1440,7 +1440,15 @@ class AnophelesSnpData(
         with self._dask_progress(desc="Compute SNP allele counts"):
             ac = ac.compute()
 
-        results = dict(ac=ac.values)
+        # Cache variant metadata alongside allele counts so that
+        # snp_allele_counts(return_dataset=True) can reconstruct a
+        # Dataset without a redundant snp_calls() invocation.
+        results = dict(
+            ac=ac.values,
+            variant_position=ds_snps["variant_position"].values,
+            variant_contig=ds_snps["variant_contig"].values,
+            variant_allele=ds_snps["variant_allele"].values,
+        )
 
         return results
 
@@ -1481,7 +1489,9 @@ class AnophelesSnpData(
         chunks: base_params.chunks = base_params.native_chunks,
         return_dataset: base_params.return_dataset = False,
     ) -> Any:
-        name = "snp_allele_counts_v2"
+        # Bumped to v3 to include variant metadata in cached results,
+        # enabling Dataset reconstruction without extra snp_calls().
+        name = "snp_allele_counts_v3"
 
         base_params._validate_sample_selection_params(
             sample_query=sample_query, sample_indices=sample_indices
@@ -1547,24 +1557,23 @@ class AnophelesSnpData(
         ac = results["ac"]
 
         if return_dataset:
-            ds = self.snp_calls(
-                region=params["region"],
-                sample_sets=params["sample_sets"],
-                sample_indices=params["sample_indices"],
-                site_mask=params["site_mask"],
-                site_class=site_class,
-                cohort_size=cohort_size,
-                min_cohort_size=min_cohort_size,
-                max_cohort_size=max_cohort_size,
-                random_seed=random_seed,
-                inline_array=inline_array,
-                chunks=chunks,
-            )
-            ds = ds.assign(
-                variant_allele_count=(
-                    ds["variant_allele"].dims,
-                    ac,
-                )
+            # Reconstruct the Dataset from cached arrays — no extra
+            # snp_calls() invocation required.
+            ds = xr.Dataset(
+                coords={
+                    "variant_position": (DIM_VARIANT, results["variant_position"]),
+                    "variant_contig": (DIM_VARIANT, results["variant_contig"]),
+                },
+                data_vars={
+                    "variant_allele": (
+                        (DIM_VARIANT, DIM_ALLELE),
+                        results["variant_allele"],
+                    ),
+                    "variant_allele_count": (
+                        (DIM_VARIANT, DIM_ALLELE),
+                        ac,
+                    ),
+                },
             )
             return ds
 
@@ -1911,7 +1920,9 @@ class AnophelesSnpData(
             sample_query=sample_query, sample_indices=sample_indices
         )
 
-        ds = self.snp_allele_counts(
+        # Get the full SNP calls dataset (genotypes, sample_id, variant info).
+        # N.B., snp_calls() uses an LRU cache so this is efficient.
+        ds = self.snp_calls(
             region=region,
             sample_sets=sample_sets,
             sample_query=sample_query,
@@ -1925,9 +1936,33 @@ class AnophelesSnpData(
             random_seed=random_seed,
             inline_array=inline_array,
             chunks=chunks,
-            return_dataset=True,
         )
-        ac = ds["variant_allele_count"].values
+
+        # Get allele counts (uses the results cache, so no redundant
+        # genotype computation even if snp_calls was already called).
+        ac = self.snp_allele_counts(
+            region=region,
+            sample_sets=sample_sets,
+            sample_query=sample_query,
+            sample_query_options=sample_query_options,
+            sample_indices=sample_indices,
+            site_mask=site_mask,
+            site_class=site_class,
+            cohort_size=cohort_size,
+            min_cohort_size=min_cohort_size,
+            max_cohort_size=max_cohort_size,
+            random_seed=random_seed,
+            inline_array=inline_array,
+            chunks=chunks,
+        )
+
+        # Attach allele counts to the dataset.
+        ds = ds.assign(
+            variant_allele_count=(
+                ds["variant_allele"].dims,
+                ac,
+            )
+        )
 
         # Locate biallelic SNPs.
         loc_bi = allel.AlleleCountsArray(ac).is_biallelic()
@@ -2185,7 +2220,7 @@ class AnophelesSnpData(
         thin_offset: base_params.thin_offset,
         inline_array: base_params.inline_array,
         chunks: base_params.chunks,
-    ) -> Dict[str, np.ndarray]:
+    ) -> xr.Dataset:
         # Note: this function uses sample_indices and should not expect a sample_query.
 
         # Access biallelic SNPs.

--- a/tests/anoph/test_distance.py
+++ b/tests/anoph/test_distance.py
@@ -124,17 +124,6 @@ def check_biallelic_diplotype_pairwise_distance(*, api, data_params, metric):
     assert n_snps_used >= n_snps
     assert n_snps_used <= n_snps_available
 
-    assert isinstance(dist, np.ndarray)
-    assert isinstance(samples, np.ndarray)
-    assert isinstance(n_snps_used, int)
-
-    assert dist.ndim == 1  # condensed form distance matrix
-    assert dist.shape[0] == int((n_samples * (n_samples - 1)) / 2)
-    assert samples.ndim == 1
-    assert samples.shape[0] == n_samples
-    assert n_snps_used >= n_snps
-    assert n_snps_used <= n_snps_available
-
     ds = api.biallelic_diplotype_pairwise_distances(
         n_snps=n_snps,
         metric=metric,

--- a/tests/anoph/test_distance.py
+++ b/tests/anoph/test_distance.py
@@ -124,18 +124,29 @@ def check_biallelic_diplotype_pairwise_distance(*, api, data_params, metric):
     assert n_snps_used >= n_snps
     assert n_snps_used <= n_snps_available
 
-    # Check types.
     assert isinstance(dist, np.ndarray)
     assert isinstance(samples, np.ndarray)
     assert isinstance(n_snps_used, int)
 
-    # Check sizes.
     assert dist.ndim == 1  # condensed form distance matrix
     assert dist.shape[0] == int((n_samples * (n_samples - 1)) / 2)
     assert samples.ndim == 1
     assert samples.shape[0] == n_samples
     assert n_snps_used >= n_snps
     assert n_snps_used <= n_snps_available
+
+    ds = api.biallelic_diplotype_pairwise_distances(
+        n_snps=n_snps,
+        metric=metric,
+        return_dataset=True,
+        **data_params,
+    )
+    import xarray as xr
+    assert isinstance(ds, xr.Dataset)
+    assert "dist" in ds
+    assert "sample_id" in ds.coords
+    assert ds["dist"].shape == (n_samples, n_samples)
+    assert ds.attrs["n_snps_used"] == n_snps_used
 
 
 @parametrize_with_cases("fixture,api", cases=".")

--- a/tests/anoph/test_distance.py
+++ b/tests/anoph/test_distance.py
@@ -142,6 +142,7 @@ def check_biallelic_diplotype_pairwise_distance(*, api, data_params, metric):
         **data_params,
     )
     import xarray as xr
+
     assert isinstance(ds, xr.Dataset)
     assert "dist" in ds
     assert "sample_id" in ds.coords

--- a/tests/anoph/test_hapclust.py
+++ b/tests/anoph/test_hapclust.py
@@ -124,3 +124,37 @@ def test_plot_haplotype_sharing_chord(fixture, api: AnophelesHapClustAnalysis):
             show=False,
         )
         assert fig is not None
+
+
+@parametrize_with_cases("fixture,api", cases=".")
+def test_haplotype_pairwise_distances(fixture, api: AnophelesHapClustAnalysis):
+    import xarray as xr
+
+    all_sample_sets = api.sample_sets()["sample_set"].to_list()
+    region = fixture.random_region_str(region_size=5000)
+    sample_sets = [str(np.random.choice(all_sample_sets))]
+
+    # Test legacy tuple return.
+    dist, phased_samples, n_snps = api.haplotype_pairwise_distances(
+        region=region,
+        sample_sets=sample_sets,
+    )
+    assert isinstance(dist, np.ndarray)
+    assert isinstance(phased_samples, np.ndarray)
+    assert isinstance(n_snps, int)
+    assert dist.ndim == 1  # condensed form
+    # Each phased sample contributes 2 haplotypes.
+    n_haps = 2 * len(phased_samples)
+    assert dist.shape[0] == int((n_haps * (n_haps - 1)) / 2)
+
+    # Test dataset return mode.
+    ds = api.haplotype_pairwise_distances(
+        region=region,
+        sample_sets=sample_sets,
+        return_dataset=True,
+    )
+    assert isinstance(ds, xr.Dataset)
+    assert "dist" in ds
+    assert "sample_id" in ds.coords
+    assert ds["dist"].shape == (n_haps, n_haps)
+    assert ds.attrs["n_snps"] == n_snps

--- a/tests/anoph/test_snp_data.py
+++ b/tests/anoph/test_snp_data.py
@@ -1158,6 +1158,10 @@ def check_snp_allele_counts(
     assert isinstance(ds_ac, xr.Dataset)
     assert "variant_allele_count" in ds_ac
     assert_array_equal(ds_ac["variant_allele_count"].values, ac)
+    # Verify variant metadata is included.
+    assert "variant_position" in ds_ac.coords
+    assert "variant_contig" in ds_ac.coords
+    assert "variant_allele" in ds_ac
 
 
 @parametrize_with_cases(

--- a/tests/anoph/test_snp_data.py
+++ b/tests/anoph/test_snp_data.py
@@ -1146,6 +1146,19 @@ def check_snp_allele_counts(
     )
     assert_array_equal(ac, ac2)
 
+    # Check dataset return mode.
+    ds_ac = api.snp_allele_counts(
+        region=region,
+        sample_sets=sample_sets,
+        sample_query=sample_query,
+        sample_query_options=sample_query_options,
+        site_mask=site_mask,
+        return_dataset=True,
+    )
+    assert isinstance(ds_ac, xr.Dataset)
+    assert "variant_allele_count" in ds_ac
+    assert_array_equal(ds_ac["variant_allele_count"].values, ac)
+
 
 @parametrize_with_cases(
     "fixture,api", cases=".", filter=~ft.has_tag("single-sampleset")
@@ -1452,6 +1465,22 @@ def check_biallelic_snp_calls_and_diplotypes(
     assert samples.ndim == 1
     assert samples.shape[0] == gn.shape[1]
     assert samples.tolist() == expected_samples
+
+    # Check dataset return mode.
+    ds_gn = api.biallelic_diplotypes(
+        region=region,
+        sample_sets=sample_sets,
+        site_mask=site_mask,
+        site_class=site_class,
+        min_minor_ac=min_minor_ac,
+        max_missing_an=max_missing_an,
+        n_snps=n_snps,
+        return_dataset=True,
+    )
+    assert isinstance(ds_gn, xr.Dataset)
+    assert "call_diplotype" in ds_gn
+    assert_array_equal(ds_gn["call_diplotype"].values, gn)
+    assert ds_gn["sample_id"].values.tolist() == expected_samples
 
     return ds
 


### PR DESCRIPTION
Fixes #472 
- I have Added `return_dataset=True` to snp_allele_counts(), biallelic_diplotypes(), biallelic_diplotype_pairwise_distances(), and haplotype_pairwise_distances().
- Cached variant metadata alongside allele counts so `snp_allele_counts(return_dataset=True)` can build the Dataset from cache without a redundant snp_calls().
- Refactored `biallelic_snp_calls` to call snp_calls() and snp_allele_counts() separately
- Added tests for all new dataset-return paths and cleaned up duplicate assertions in `test_distance.py.`


