### PR TITLE
GH965: Normalize site_mask in g123_gwss to match g123_calibration

### DIFF
--- a/malariagen_data/anoph/g123.py
+++ b/malariagen_data/anoph/g123.py
@@ -181,7 +181,7 @@ class AnophelesG123Analysis(
         params = dict(
             contig=contig,
             sites=sites,
-            site_mask=site_mask,
+            site_mask=self._prep_optional_site_mask_param(site_mask=site_mask),
             window_size=window_size,
             sample_sets=self._prep_sample_sets_param(sample_sets=sample_sets),
             # N.B., do not be tempted to convert this sample query into integer


### PR DESCRIPTION
## Issue

In `g123_calibration()`, the `site_mask` parameter is normalized using `_prep_optional_site_mask_param()` before building the cache key. However, in `g123_gwss()`, the raw `site_mask` value is used directly without normalization.

This creates inconsistent cache behaviour: logically equivalent inputs (e.g., `DEFAULT` and the actual default mask ID) generate different cache keys, leading to unnecessary recomputation or potential cache misses.

## Solution

Added the same normalization in `g123_gwss()` to match `g123_calibration()`. This ensures consistent cache keys and improves reproducibility across the codebase without changing the public API.

## Testing

- Unit tests for G123 analysis pass locally

## Fixes #965