### PR TITLE
Make pytest functions reproducible (1/2)

### DIFF
--- a/malariagen_data/anoph/pca.py
+++ b/malariagen_data/anoph/pca.py
@@ -455,8 +455,8 @@ class AnophelesPca(
         # Apply jitter if desired - helps spread out points when tightly clustered.
         if jitter_frac:
             rng = np.random.default_rng(seed=random_seed)
-            data[x] = _jitter(data[x], jitter_frac, random_state=rng)
-            data[y] = _jitter(data[y], jitter_frac, random_state=rng)
+            data[x] = _jitter(data[x], jitter_frac, rng)
+            data[y] = _jitter(data[y], jitter_frac, rng)
 
         # Convenience variables.
         # Prevent lint error (mypy): Unsupported operand types for + ("Series[Any]" and "str")
@@ -559,9 +559,9 @@ class AnophelesPca(
         # Apply jitter if desired - helps spread out points when tightly clustered.
         if jitter_frac:
             rng = np.random.default_rng(seed=random_seed)
-            data[x] = _jitter(data[x], jitter_frac, random_state=rng)
-            data[y] = _jitter(data[y], jitter_frac, random_state=rng)
-            data[z] = _jitter(data[z], jitter_frac, random_state=rng)
+            data[x] = _jitter(data[x], jitter_frac, rng)
+            data[y] = _jitter(data[y], jitter_frac, rng)
+            data[z] = _jitter(data[z], jitter_frac, rng)
 
         # Convenience variables.
         # Prevent lint error (mypy): Unsupported operand types for + ("Series[Any]" and "str")

--- a/malariagen_data/util.py
+++ b/malariagen_data/util.py
@@ -935,7 +935,7 @@ def _hash_params(params):
     return h, s
 
 
-def _jitter(a, fraction, random_state=np.random):
+def _jitter(a, fraction, rng):
     """Jitter data by adding uniform noise scaled by the data range.
 
     Parameters
@@ -944,24 +944,17 @@ def _jitter(a, fraction, random_state=np.random):
         Input data to jitter. Can be a numpy array or pandas Series.
     fraction : float
         Controls the amplitude of the jitter relative to the data range.
-    random_state : numpy.random.Generator or module, optional
+    rng : numpy.random.Generator
         Random number generator to use. Accepts a ``numpy.random.Generator``
-        (from ``np.random.default_rng()``) or the ``numpy.random`` module.
-        Defaults to ``np.random`` (global RNG) for backward compatibility.
+        (from ``np.random.default_rng()`` or elsewhere)
 
     Returns
     -------
     array-like
         Jittered copy of the input data with the same shape and type.
-
-    Notes
-    -----
-    Prefer passing a local ``np.random.default_rng(seed=...)`` to avoid
-    mutating global RNG state and to ensure reproducibility.
-
     """
     r = a.max() - a.min()
-    return a + fraction * random_state.uniform(-r, r, a.shape)
+    return a + fraction * rng.uniform(-r, r, a.shape)
 
 
 class CacheMiss(Exception):

--- a/tests/anoph/conftest.py
+++ b/tests/anoph/conftest.py
@@ -51,7 +51,14 @@ def create_rng(context: str) -> np.random.Generator:
 
 
 def pytest_report_header(config):
-    print("global seed:", GLOBAL_SEED)
+    return f"global seed: {GLOBAL_SEED}"
+
+
+@pytest.fixture(name="rng")
+def test_rng_fixture(request):
+    # The nodeid is the complete name of the pytest function and
+    # is unique across the tests
+    return create_rng(request.node.nodeid)
 
 
 @pytest.fixture(scope="session")

--- a/tests/anoph/conftest.py
+++ b/tests/anoph/conftest.py
@@ -1,6 +1,5 @@
 import hashlib
 import json
-import secrets
 import shutil
 import string
 from pathlib import Path
@@ -40,25 +39,19 @@ from malariagen_data.util import _gff3_parse_attributes
 # In order for reproducibility to work, it is essential to *not* use the
 # python random library or any legacy numpy.random calls to generate data.
 
-GLOBAL_SEED = secrets.randbits(128)
 
-
-def create_rng(context: str) -> np.random.Generator:
+def create_rng(global_seed: int, context: str) -> np.random.Generator:
     # Hash the string to an integer so we can make it into another seed
     digest = hashlib.shake_128(context.encode("utf-8")).hexdigest(16)
     context_seed = int(digest, 16)
-    return np.random.default_rng([context_seed, GLOBAL_SEED])
-
-
-def pytest_report_header(config):
-    return f"global seed: {GLOBAL_SEED}"
+    return np.random.default_rng([context_seed, global_seed])
 
 
 @pytest.fixture(name="rng")
-def test_rng_fixture(request):
+def test_rng_fixture(request, global_seed):
     # The nodeid is the complete name of the pytest function and
     # is unique across the tests
-    return create_rng(request.node.nodeid)
+    return create_rng(global_seed, request.node.nodeid)
 
 
 @pytest.fixture(scope="session")
@@ -902,7 +895,7 @@ def simulate_cnv_discordant_read_calls(
     # consistent number of variants for each contig for all sample set, otherwise the shapes will not align,
     # which will raise an error and cause test failures.
     # Use the same rng per contig, otherwise n_cnv_variants (and shapes) will not align.
-    contig_rngs = create_rng("contigs").spawn(len(contigs))
+    contig_rngs = create_rng(42, "contigs").spawn(len(contigs))
 
     for contig_rng, contig in zip(contig_rngs, contigs):
         # Create the contig group.
@@ -3498,25 +3491,25 @@ class As1Simulator(AnophelesSimulator):
 
 
 @pytest.fixture(scope="session")
-def ag3_sim_fixture(fixture_dir):
-    return Ag3Simulator(fixture_dir=fixture_dir, rng=create_rng("Ag3"))
+def ag3_sim_fixture(fixture_dir, global_seed):
+    return Ag3Simulator(fixture_dir=fixture_dir, rng=create_rng(global_seed, "Ag3"))
 
 
 @pytest.fixture(scope="session")
-def af1_sim_fixture(fixture_dir):
-    return Af1Simulator(fixture_dir=fixture_dir, rng=create_rng("Af1"))
+def af1_sim_fixture(fixture_dir, global_seed):
+    return Af1Simulator(fixture_dir=fixture_dir, rng=create_rng(global_seed, "Af1"))
 
 
 @pytest.fixture(scope="session")
-def adir1_sim_fixture(fixture_dir):
-    return Adir1Simulator(fixture_dir=fixture_dir, rng=create_rng("Adir1"))
+def adir1_sim_fixture(fixture_dir, global_seed):
+    return Adir1Simulator(fixture_dir=fixture_dir, rng=create_rng(global_seed, "Adir1"))
 
 
 @pytest.fixture(scope="session")
-def amin1_sim_fixture(fixture_dir):
-    return Amin1Simulator(fixture_dir=fixture_dir, rng=create_rng("Amin1"))
+def amin1_sim_fixture(fixture_dir, global_seed):
+    return Amin1Simulator(fixture_dir=fixture_dir, rng=create_rng(global_seed, "Amin1"))
 
 
 @pytest.fixture(scope="session")
-def as1_sim_fixture(fixture_dir):
-    return As1Simulator(fixture_dir=fixture_dir, rng=create_rng("As1"))
+def as1_sim_fixture(fixture_dir, global_seed):
+    return As1Simulator(fixture_dir=fixture_dir, rng=create_rng(global_seed, "As1"))

--- a/tests/anoph/test_aim_data.py
+++ b/tests/anoph/test_aim_data.py
@@ -80,7 +80,7 @@ def test_aim_variants(aims, ag3_sim_api):
 
 
 @pytest.mark.parametrize("aims", ["gambcolu_vs_arab", "gamb_vs_colu"])
-def test_aim_calls(aims, ag3_sim_api):
+def test_aim_calls(aims, ag3_sim_api, rng: np.random.Generator):
     api = ag3_sim_api
 
     # Parametrize sample_sets.
@@ -88,9 +88,9 @@ def test_aim_calls(aims, ag3_sim_api):
     all_releases = api.releases
     parametrize_sample_sets = [
         None,
-        str(np.random.choice(all_sample_sets)),
-        np.random.choice(all_sample_sets, size=2, replace=False).tolist(),
-        np.random.choice(all_releases),
+        rng.choice(all_sample_sets),
+        rng.choice(all_sample_sets, 2, replace=False).tolist(),
+        rng.choice(all_releases),
     ]
 
     # Parametrize sample_query.
@@ -171,7 +171,7 @@ def test_aim_calls_errors(ag3_sim_api):
 
 
 @pytest.mark.parametrize("aims", ["gambcolu_vs_arab", "gamb_vs_colu"])
-def test_plot_aim_heatmap(aims, ag3_sim_api):
+def test_plot_aim_heatmap(aims, ag3_sim_api, rng: np.random.Generator):
     api = ag3_sim_api
 
     # Parametrize sample_sets.
@@ -179,9 +179,9 @@ def test_plot_aim_heatmap(aims, ag3_sim_api):
     all_releases = api.releases
     parametrize_sample_sets = [
         None,
-        str(np.random.choice(all_sample_sets)),
-        np.random.choice(all_sample_sets, size=2, replace=False).tolist(),
-        np.random.choice(all_releases),
+        rng.choice(all_sample_sets),
+        rng.choice(all_sample_sets, 2, replace=False).tolist(),
+        rng.choice(all_releases),
     ]
 
     # Parametrize sample_query.

--- a/tests/anoph/test_base.py
+++ b/tests/anoph/test_base.py
@@ -261,11 +261,11 @@ def test_prep_sample_sets_param(ag3_sim_api: AnophelesBase):
 
 
 @parametrize_with_cases("fixture,api", cases=".")
-def test_lookup_study(fixture, api):
+def test_lookup_study(fixture, api, rng: np.random.Generator):
     # Set up test.
     df_sample_sets = api.sample_sets()
     all_sample_sets = df_sample_sets["sample_set"].values
-    sample_set = np.random.choice(all_sample_sets)
+    sample_set = rng.choice(all_sample_sets)
 
     study_rec_by_sample_set = api.lookup_study(sample_set)
     df_sample_set = df_sample_sets.set_index("sample_set").loc[sample_set]

--- a/tests/anoph/test_cnv_frq.py
+++ b/tests/anoph/test_cnv_frq.py
@@ -90,13 +90,14 @@ expected_types = ["amp", "del"]
 @parametrize_with_cases("fixture,api", cases=".")
 def test_gene_cnv_frequencies_with_str_cohorts(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesCnvFrequencyAnalysis,
     cohorts,
 ):
-    region = str(np.random.choice(api.contigs))
+    region = rng.choice(api.contigs)
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
-    sample_sets = str(np.random.choice(all_sample_sets))
-    min_cohort_size = int(np.random.randint(0, 3))
+    sample_sets = rng.choice(all_sample_sets)
+    min_cohort_size = rng.integers(0, 3, dtype=int)
 
     # Set up call params.
     params = dict(
@@ -141,13 +142,14 @@ def test_gene_cnv_frequencies_with_str_cohorts(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_gene_cnv_frequencies_with_min_cohort_size(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesCnvFrequencyAnalysis,
     min_cohort_size,
 ):
     # Pick test parameters at random.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
-    sample_sets = str(np.random.choice(all_sample_sets))
-    region = str(np.random.choice(api.contigs))
+    sample_sets = rng.choice(all_sample_sets)
+    region = rng.choice(api.contigs)
     cohorts = "admin1_year"
 
     # Set up call params.
@@ -192,18 +194,17 @@ def test_gene_cnv_frequencies_with_min_cohort_size(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_gene_cnv_frequencies_with_str_cohorts_and_sample_query(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesCnvFrequencyAnalysis,
 ):
     # Pick test parameters at random.
     sample_sets = None
     min_cohort_size = 0
-    region = str(np.random.choice(api.contigs))
-    cohorts = str(
-        np.random.choice(["admin1_year", "admin1_month", "admin2_year", "admin2_month"])
-    )
+    region = rng.choice(api.contigs)
+    cohorts = rng.choice(["admin1_year", "admin1_month", "admin2_year", "admin2_month"])
     df_samples = api.sample_metadata(sample_sets=sample_sets)
     countries = df_samples["country"].unique()
-    country = str(np.random.choice(countries))
+    country = rng.choice(countries)
     sample_query = f"country == '{country}'"
 
     # Figure out expected cohort labels.
@@ -240,18 +241,17 @@ def test_gene_cnv_frequencies_with_str_cohorts_and_sample_query(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_gene_cnv_frequencies_with_str_cohorts_and_sample_query_options(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesCnvFrequencyAnalysis,
 ):
     # Pick test parameters at random.
     sample_sets = None
     min_cohort_size = 0
-    region = str(np.random.choice(api.contigs))
-    cohorts = str(
-        np.random.choice(["admin1_year", "admin1_month", "admin2_year", "admin2_month"])
-    )
+    region = rng.choice(api.contigs)
+    cohorts = rng.choice(["admin1_year", "admin1_month", "admin2_year", "admin2_month"])
     df_samples = api.sample_metadata(sample_sets=sample_sets)
     countries = df_samples["country"].unique().tolist()
-    countries_list = np.random.choice(countries, size=2, replace=False).tolist()
+    countries_list = rng.choice(countries, 2, replace=False)
     sample_query_options = {
         "local_dict": {
             "countries_list": countries_list,
@@ -297,12 +297,12 @@ def test_gene_cnv_frequencies_with_str_cohorts_and_sample_query_options(
 
 @parametrize_with_cases("fixture,api", cases=".")
 def test_gene_cnv_frequencies_with_dict_cohorts(
-    fixture, api: AnophelesCnvFrequencyAnalysis
+    fixture, rng: np.random.Generator, api: AnophelesCnvFrequencyAnalysis
 ):
     # Pick test parameters at random.
     sample_sets = None  # all sample sets
-    min_cohort_size = int(np.random.randint(0, 3))
-    region = str(np.random.choice(api.contigs))
+    min_cohort_size = rng.integers(0, 3, dtype=int)
+    region = rng.choice(api.contigs)
 
     # Create cohorts by country.
     df_samples = api.sample_metadata(sample_sets=sample_sets)
@@ -337,14 +337,15 @@ def test_gene_cnv_frequencies_with_dict_cohorts(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_gene_cnv_frequencies_without_drop_invariant(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesCnvFrequencyAnalysis,
 ):
     # Pick test parameters at random.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
-    sample_sets = str(np.random.choice(all_sample_sets))
-    min_cohort_size = int(np.random.randint(0, 3))
-    region = str(np.random.choice(api.contigs))
-    cohorts = str(np.random.choice(["admin1_year", "admin2_month", "country"]))
+    sample_sets = rng.choice(all_sample_sets)
+    min_cohort_size = rng.integers(0, 3, dtype=int)
+    region = rng.choice(api.contigs)
+    cohorts = rng.choice(["admin1_year", "admin2_month", "country"])
 
     # Figure out expected cohort labels.
     df_samples = api.sample_metadata(sample_sets=sample_sets)
@@ -392,13 +393,14 @@ def test_gene_cnv_frequencies_without_drop_invariant(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_gene_cnv_frequencies_with_bad_region(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesCnvFrequencyAnalysis,
 ):
     # Pick test parameters at random.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
-    sample_sets = str(np.random.choice(all_sample_sets))
-    min_cohort_size = int(np.random.randint(0, 3))
-    cohorts = str(np.random.choice(["admin1_year", "admin2_month", "country"]))
+    sample_sets = rng.choice(all_sample_sets)
+    min_cohort_size = rng.integers(0, 3, dtype=int)
+    cohorts = rng.choice(["admin1_year", "admin2_month", "country"])
 
     # Set up call params.
     params = dict(
@@ -418,13 +420,14 @@ def test_gene_cnv_frequencies_with_bad_region(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_gene_cnv_frequencies_with_max_coverage_variance(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesCnvFrequencyAnalysis,
     max_coverage_variance,
 ):
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
-    sample_sets = str(np.random.choice(all_sample_sets))
-    cohorts = str(np.random.choice(["admin1_year", "admin2_month", "country"]))
-    region = str(np.random.choice(api.contigs))
+    sample_sets = rng.choice(all_sample_sets)
+    cohorts = rng.choice(["admin1_year", "admin2_month", "country"])
+    region = rng.choice(api.contigs)
 
     params = dict(
         region=region,
@@ -471,11 +474,13 @@ def test_gene_cnv_frequencies_with_max_coverage_variance(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_gene_cnv_frequencies_advanced_with_area_by(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesCnvFrequencyAnalysis,
     area_by,
 ):
     check_gene_cnv_frequencies_advanced(
         api=api,
+        rng=rng,
         area_by=area_by,
     )
 
@@ -484,11 +489,13 @@ def test_gene_cnv_frequencies_advanced_with_area_by(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_gene_cnv_frequencies_advanced_with_period_by(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesCnvFrequencyAnalysis,
     period_by,
 ):
     check_gene_cnv_frequencies_advanced(
         api=api,
+        rng=rng,
         period_by=period_by,
     )
 
@@ -496,16 +503,18 @@ def test_gene_cnv_frequencies_advanced_with_period_by(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_gene_cnv_frequencies_advanced_with_sample_query(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesCnvFrequencyAnalysis,
 ):
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
     df_samples = api.sample_metadata(sample_sets=all_sample_sets)
     countries = df_samples["country"].unique()
-    country = str(np.random.choice(countries))
+    country = rng.choice(countries)
     sample_query = f"country == '{country}'"
 
     check_gene_cnv_frequencies_advanced(
         api=api,
+        rng=rng,
         sample_sets=all_sample_sets,
         sample_query=sample_query,
         min_cohort_size=0,
@@ -515,12 +524,13 @@ def test_gene_cnv_frequencies_advanced_with_sample_query(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_gene_cnv_frequencies_advanced_with_sample_query_options(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesCnvFrequencyAnalysis,
 ):
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
     df_samples = api.sample_metadata(sample_sets=all_sample_sets)
     countries = df_samples["country"].unique().tolist()
-    countries_list = np.random.choice(countries, size=2, replace=False).tolist()
+    countries_list = rng.choice(countries, 2, replace=False)
     sample_query_options = {
         "local_dict": {
             "countries_list": countries_list,
@@ -530,6 +540,7 @@ def test_gene_cnv_frequencies_advanced_with_sample_query_options(
 
     check_gene_cnv_frequencies_advanced(
         api=api,
+        rng=rng,
         sample_sets=all_sample_sets,
         sample_query=sample_query,
         sample_query_options=sample_query_options,
@@ -541,19 +552,21 @@ def test_gene_cnv_frequencies_advanced_with_sample_query_options(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_gene_cnv_frequencies_advanced_with_min_cohort_size(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesCnvFrequencyAnalysis,
     min_cohort_size,
 ):
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
     area_by = "admin1_iso"
     period_by = "year"
-    region = str(np.random.choice(api.contigs))
+    region = rng.choice(api.contigs)
 
     if min_cohort_size <= 10:
         # Expect this to find at least one cohort, so go ahead with full
         # checks.
         check_gene_cnv_frequencies_advanced(
             api=api,
+            rng=rng,
             region=region,
             sample_sets=all_sample_sets,
             min_cohort_size=min_cohort_size,
@@ -577,19 +590,21 @@ def test_gene_cnv_frequencies_advanced_with_min_cohort_size(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_gene_cnv_frequencies_advanced_with_max_coverage_variance(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesCnvFrequencyAnalysis,
     max_coverage_variance,
 ):
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
     area_by = "admin1_iso"
     period_by = "year"
-    region = str(np.random.choice(api.contigs))
+    region = rng.choice(api.contigs)
 
     if max_coverage_variance >= 0.4:
         # Expect this to find at least one cohort, so go ahead with full
         # checks.
         check_gene_cnv_frequencies_advanced(
             api=api,
+            rng=rng,
             region=region,
             sample_sets=all_sample_sets,
             max_coverage_variance=max_coverage_variance,
@@ -612,16 +627,18 @@ def test_gene_cnv_frequencies_advanced_with_max_coverage_variance(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_gene_cnv_frequencies_advanced_with_nobs_mode(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesCnvFrequencyAnalysis,
     nobs_mode,
 ):
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
     area_by = "admin1_iso"
     period_by = "year"
-    region = str(np.random.choice(api.contigs))
+    region = rng.choice(api.contigs)
 
     check_gene_cnv_frequencies_advanced(
         api=api,
+        rng=rng,
         region=region,
         sample_sets=all_sample_sets,
         nobs_mode=nobs_mode,
@@ -634,17 +651,19 @@ def test_gene_cnv_frequencies_advanced_with_nobs_mode(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_gene_cnv_frequencies_advanced_with_variant_query(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesCnvFrequencyAnalysis,
     variant_query_option,
 ):
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
     area_by = "admin1_iso"
     period_by = "year"
-    region = str(np.random.choice(api.contigs))
+    region = rng.choice(api.contigs)
     variant_query = f"cnv_type == '{variant_query_option}'"
 
     check_gene_cnv_frequencies_advanced(
         api=api,
+        rng=rng,
         region=region,
         sample_sets=all_sample_sets,
         variant_query=variant_query,
@@ -695,6 +714,7 @@ def check_gene_cnv_frequencies(
 def check_gene_cnv_frequencies_advanced(
     *,
     api: AnophelesCnvFrequencyAnalysis,
+    rng: np.random.Generator,
     region=None,
     area_by="admin1_iso",
     period_by="year",
@@ -708,20 +728,20 @@ def check_gene_cnv_frequencies_advanced(
 ):
     # Pick test parameters at random.
     if region is None:
-        region = str(np.random.choice(api.contigs))
+        region = rng.choice(api.contigs)
     if area_by is None:
-        area_by = str(np.random.choice(["country", "admin1_iso", "admin2_name"]))
+        area_by = rng.choice(["country", "admin1_iso", "admin2_name"])
     if period_by is None:
-        period_by = str(np.random.choice(["year", "quarter", "month", "random_year"]))
+        period_by = rng.choice(["year", "quarter", "month", "random_year"])
     if sample_sets is None:
         all_sample_sets = api.sample_sets()["sample_set"].to_list()
-        sample_sets = str(np.random.choice(all_sample_sets))
+        sample_sets = rng.choice(all_sample_sets)
     if min_cohort_size is None:
-        min_cohort_size = int(np.random.randint(0, 3))
+        min_cohort_size = rng.integers(0, 3, dtype=int)
 
     if period_by == "random_year":
         # Add a random_year column to the sample metadata, if there isn't already.
-        api = add_random_year(api=api)
+        api = add_random_year(api=api, rng=rng)
 
     # Run function under test.
     ds = api.gene_cnv_frequencies_advanced(
@@ -739,8 +759,8 @@ def check_gene_cnv_frequencies_advanced(
     # Check the result.
     assert isinstance(ds, xr.Dataset)
     check_plot_frequencies_time_series(api, ds)
-    check_plot_frequencies_time_series_with_taxa(api, ds)
-    check_plot_frequencies_time_series_with_areas(api, ds)
+    check_plot_frequencies_time_series_with_taxa(api, ds, rng)
+    check_plot_frequencies_time_series_with_areas(api, ds, rng)
     if variant_query is None:
         check_plot_frequencies_interactive_map(api, ds)
     assert set(ds.dims) == {"cohorts", "variants"}

--- a/tests/anoph/test_frq.py
+++ b/tests/anoph/test_frq.py
@@ -35,12 +35,12 @@ def check_plot_frequencies_time_series(api, ds):
     assert isinstance(fig, go.Figure)
 
 
-def check_plot_frequencies_time_series_with_taxa(api, ds):
+def check_plot_frequencies_time_series_with_taxa(api, ds, rng: np.random.Generator):
     # Trim things down a bit for speed.
     ds = ds.isel(variants=slice(0, 100))
 
     taxa = list(ds.cohort_taxon.to_dataframe()["cohort_taxon"].unique())
-    taxon = str(np.random.choice(taxa))
+    taxon = rng.choice(taxa)
 
     # Plot with taxon.
     fig = api.plot_frequencies_time_series(ds, show=False, taxa=taxon)
@@ -55,7 +55,7 @@ def check_plot_frequencies_time_series_with_taxa(api, ds):
     assert isinstance(fig, go.Figure)
 
 
-def check_plot_frequencies_time_series_with_areas(api, ds):
+def check_plot_frequencies_time_series_with_areas(api, ds, rng: np.random.Generator):
     # Trim things down a bit for speed.
     ds = ds.isel(variants=slice(0, 100))
 
@@ -65,12 +65,9 @@ def check_plot_frequencies_time_series_with_areas(api, ds):
 
     # Pick a random area and areas from valid areas.
     cohorts_areas = df_cohorts["cohort_area"].dropna().unique().tolist()
-    area = np.random.choice(cohorts_areas)
-    areas = np.random.choice(
-        cohorts_areas,
-        size=int(np.random.randint(1, len(cohorts_areas) + 1)),
-        replace=False,
-    ).tolist()
+    area = rng.choice(cohorts_areas)
+    num_areas = rng.integers(1, len(cohorts_areas), endpoint=True)
+    areas = rng.choice(cohorts_areas, num_areas, replace=False).tolist()
 
     # Plot with area.
     fig = api.plot_frequencies_time_series(ds, show=False, areas=area)
@@ -98,7 +95,7 @@ def check_plot_frequencies_interactive_map(api, ds):
     assert isinstance(fig, ipywidgets.Widget)
 
 
-def add_random_year(*, api):
+def add_random_year(*, api, rng: np.random.Generator):
     # Add a 'random_year' column to the sample_metadata, if it doesn't exist.
 
     # Get the existing sample metadata.
@@ -108,10 +105,8 @@ def add_random_year(*, api):
     # Otherwise we'll get multiple columns with different suffixes, e.g. 'random_year_x' and 'random_year_y'.
     if "random_year" not in sample_metadata_df.columns:
         # Avoid "ValueError: No cohorts available" by selecting only a few different years at random.
-        selected_years = np.random.choice(
-            range(1900, 2100), size=3, replace=False
-        ).tolist()
-        random_years_as_list = np.random.choice(selected_years, len(sample_metadata_df))
+        selected_years = rng.choice(range(1900, 2100), 3, replace=False)
+        random_years_as_list = rng.choice(selected_years, len(sample_metadata_df))
         random_years_as_period_index = pd.PeriodIndex(random_years_as_list, freq="Y")
         extra_metadata_df = pd.DataFrame(
             {

--- a/tests/anoph/test_genome_features.py
+++ b/tests/anoph/test_genome_features.py
@@ -166,7 +166,9 @@ def test_plot_genes(fixture, api: AnophelesGenomeFeaturesData):
 
 
 @parametrize_with_cases("fixture,api", cases=".")
-def test_plot_genes_with_gene_labels(fixture, api: AnophelesGenomeFeaturesData):
+def test_plot_genes_with_gene_labels(
+    fixture, rng: np.random.Generator, api: AnophelesGenomeFeaturesData
+):
     # For each contig in the fixture...
     for contig in fixture.contigs:
         # Get the genes for this contig.
@@ -177,10 +179,10 @@ def test_plot_genes_with_gene_labels(fixture, api: AnophelesGenomeFeaturesData):
         # If there are no genes, we cannot label them.
         if not genes_df.empty:
             # Get a random number of genes to sample.
-            random_genes_n = np.random.randint(low=1, high=len(genes_df) + 1)
+            random_genes_n = rng.integers(low=1, high=len(genes_df), endpoint=True)
 
             # Get a random sample of genes.
-            random_sample_genes_df = genes_df.sample(n=random_genes_n)
+            random_sample_genes_df = genes_df.sample(n=random_genes_n, random_state=rng)
 
             # Put the random gene "ID" and its "Name" in a dictionary.
             random_gene_labels = dict(
@@ -198,10 +200,12 @@ def test_plot_genes_with_gene_labels(fixture, api: AnophelesGenomeFeaturesData):
 
 
 @parametrize_with_cases("fixture,api", cases=".")
-def test_plot_transcript(fixture, api: AnophelesGenomeFeaturesData):
+def test_plot_transcript(
+    fixture, rng: np.random.Generator, api: AnophelesGenomeFeaturesData
+):
     for contig in fixture.contigs:
         df_transcripts = api.genome_features(region=contig).query("type == 'mRNA'")
-        transcript = np.random.choice(df_transcripts["ID"].values)
+        transcript = rng.choice(df_transcripts["ID"].values)
         fig = api.plot_transcript(transcript=transcript, show=False)
         assert isinstance(fig, bokeh.plotting.figure)
 
@@ -230,7 +234,7 @@ def test_gh334(gh334_api):
 
 
 @pytest.mark.parametrize("chrom", ["2RL", "3RL"])
-def test_genome_features_virtual_contigs(ag3_sim_api, chrom):
+def test_genome_features_virtual_contigs(ag3_sim_api, chrom, rng: np.random.Generator):
     api = ag3_sim_api
     contig_r, contig_l = api.virtual_contigs[chrom]
     df_r = api.genome_features(region=contig_r)
@@ -247,7 +251,7 @@ def test_genome_features_virtual_contigs(ag3_sim_api, chrom):
 
     # Test with region.
     seq = api.genome_sequence(region=chrom)
-    start, stop = sorted(np.random.randint(low=1, high=len(seq), size=2))
+    start, stop = sorted(rng.integers(low=1, high=len(seq), size=2))
     region = f"{chrom}:{start:,}-{stop:,}"
     df = api.genome_features(region=region)
     assert isinstance(df, pd.DataFrame)

--- a/tests/anoph/test_genome_sequence.py
+++ b/tests/anoph/test_genome_sequence.py
@@ -94,11 +94,11 @@ def test_genome_sequence(fixture, api):
 
 
 @parametrize_with_cases("fixture,api", cases=".")
-def test_genome_sequence_region(fixture, api):
+def test_genome_sequence_region(fixture, api, rng: np.random.Generator):
     for contig in fixture.contigs:
         contig_seq = api.genome_sequence(region=contig)
         # Pick a random start and stop position.
-        start, stop = sorted(np.random.randint(low=1, high=len(contig_seq), size=2))
+        start, stop = sorted(rng.integers(low=1, high=len(contig_seq), size=2))
         region = f"{contig}:{start:,}-{stop:,}"
         seq = api.genome_sequence(region=region)
         assert isinstance(seq, da.Array)
@@ -120,7 +120,7 @@ def test_virtual_contigs(ag3_sim_api):
 
 
 @pytest.mark.parametrize("chrom", ["2RL", "3RL"])
-def test_genome_sequence_virtual_contigs(ag3_sim_api, chrom):
+def test_genome_sequence_virtual_contigs(ag3_sim_api, chrom, rng: np.random.Generator):
     api = ag3_sim_api
     contig_r, contig_l = api.virtual_contigs[chrom]
     seq_r = api.genome_sequence(region=contig_r)
@@ -137,7 +137,7 @@ def test_genome_sequence_virtual_contigs(ag3_sim_api, chrom):
     )
 
     # Test with region.
-    start, stop = sorted(np.random.randint(low=1, high=len(seq), size=2))
+    start, stop = sorted(rng.integers(low=1, high=len(seq), size=2))
     region = f"{chrom}:{start:,}-{stop:,}"
     seq_region = api.genome_sequence(region=region)
     assert isinstance(seq_region, da.Array)

--- a/tests/anoph/test_hap_frq.py
+++ b/tests/anoph/test_hap_frq.py
@@ -105,15 +105,11 @@ def check_hap_frequencies(*, api, df, sample_sets, cohorts, min_cohort_size):
     assert sorted(df.columns.tolist()) == sorted(expected_fields)
 
 
-def check_hap_frequencies_advanced(
-    *,
-    api,
-    ds,
-):
+def check_hap_frequencies_advanced(*, api, ds, rng: np.random.Generator):
     assert isinstance(ds, xr.Dataset)
     check_plot_frequencies_time_series(api, ds)
-    check_plot_frequencies_time_series_with_taxa(api, ds)
-    check_plot_frequencies_time_series_with_areas(api, ds)
+    check_plot_frequencies_time_series_with_taxa(api, ds, rng)
+    check_plot_frequencies_time_series_with_areas(api, ds, rng)
     check_plot_frequencies_interactive_map(api, ds)
     assert set(ds.dims) == {"cohorts", "variants"}
 
@@ -161,13 +157,14 @@ def check_hap_frequencies_advanced(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_hap_frequencies_with_str_cohorts(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesHapFrequencyAnalysis,
     cohorts,
 ):
     # Pick test parameters at random.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
-    sample_sets = str(np.random.choice(all_sample_sets))
-    min_cohort_size = int(np.random.randint(0, 3))
+    sample_sets = rng.choice(all_sample_sets)
+    min_cohort_size = rng.integers(0, 3, dtype=int)
     region = fixture.random_region_str()
 
     # Set up call params.
@@ -210,16 +207,20 @@ def test_hap_frequencies_with_str_cohorts(
 )
 @parametrize_with_cases("fixture,api", cases=".")
 def test_hap_frequencies_advanced(
-    fixture, api: AnophelesHapFrequencyAnalysis, area_by, period_by
+    fixture,
+    rng: np.random.Generator,
+    api: AnophelesHapFrequencyAnalysis,
+    area_by,
+    period_by,
 ):
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
-    sample_sets = str(np.random.choice(all_sample_sets))
-    min_cohort_size = int(np.random.randint(0, 3))
+    sample_sets = rng.choice(all_sample_sets)
+    min_cohort_size = rng.integers(0, 3, dtype=int)
     region = fixture.random_region_str()
 
     if period_by == "random_year":
         # Add a random_year column to the sample metadata, if there isn't already.
-        api = add_random_year(api=api)
+        api = add_random_year(api=api, rng=rng)
 
     # Set up call params.
     params_advanced = dict(
@@ -239,4 +240,4 @@ def test_hap_frequencies_advanced(
         raise
 
     # Standard checks.
-    check_hap_frequencies_advanced(api=api, ds=ds_hap)
+    check_hap_frequencies_advanced(api=api, ds=ds_hap, rng=rng)

--- a/tests/anoph/test_hapclust.py
+++ b/tests/anoph/test_hapclust.py
@@ -73,7 +73,9 @@ def case_af1_sim(af1_sim_fixture, af1_sim_api):
 
 
 @parametrize_with_cases("fixture,api", cases=".")
-def test_plot_haplotype_clustering(fixture, api: AnophelesHapClustAnalysis):
+def test_plot_haplotype_clustering(
+    fixture, rng: np.random.Generator, api: AnophelesHapClustAnalysis
+):
     # Set up test parameters.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
     linkage_methods = (
@@ -85,12 +87,12 @@ def test_plot_haplotype_clustering(fixture, api: AnophelesHapClustAnalysis):
         "median",
         "ward",
     )
-    sample_queries = (None, "sex_call == 'F'")
+    sample_queries = np.array([None, "sex_call == 'F'"])
     hapclust_params = dict(
         region=fixture.random_region_str(region_size=5000),
-        sample_sets=[str(np.random.choice(all_sample_sets))],
-        linkage_method=str(np.random.choice(linkage_methods)),
-        sample_query=np.random.choice(list(sample_queries)),  # type: ignore
+        sample_sets=[rng.choice(all_sample_sets)],
+        linkage_method=str(rng.choice(linkage_methods)),
+        sample_query=rng.choice(sample_queries),
         show=False,
     )
 
@@ -99,13 +101,15 @@ def test_plot_haplotype_clustering(fixture, api: AnophelesHapClustAnalysis):
 
 
 @parametrize_with_cases("fixture,api", cases=".")
-def test_plot_haplotype_sharing_arc(fixture, api: AnophelesHapClustAnalysis):
+def test_plot_haplotype_sharing_arc(
+    fixture, rng: np.random.Generator, api: AnophelesHapClustAnalysis
+):
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
     for metric in ["unique", "absolute"]:
         fig = api.plot_haplotype_sharing_arc(
             region=fixture.random_region_str(region_size=5000),
             cohort_col="country",
-            sample_sets=[str(np.random.choice(all_sample_sets))],
+            sample_sets=[rng.choice(all_sample_sets)],
             metric=metric,
             show=False,
         )
@@ -113,13 +117,15 @@ def test_plot_haplotype_sharing_arc(fixture, api: AnophelesHapClustAnalysis):
 
 
 @parametrize_with_cases("fixture,api", cases=".")
-def test_plot_haplotype_sharing_chord(fixture, api: AnophelesHapClustAnalysis):
+def test_plot_haplotype_sharing_chord(
+    fixture, rng: np.random.Generator, api: AnophelesHapClustAnalysis
+):
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
     for metric in ["unique", "absolute"]:
         fig = api.plot_haplotype_sharing_chord(
             region=fixture.random_region_str(region_size=5000),
             cohort_col="country",
-            sample_sets=[str(np.random.choice(all_sample_sets))],
+            sample_sets=[rng.choice(all_sample_sets)],
             metric=metric,
             show=False,
         )

--- a/tests/anoph/test_igv.py
+++ b/tests/anoph/test_igv.py
@@ -78,9 +78,9 @@ def test_igv(fixture, api: AnophelesIgv):
 
 
 @parametrize_with_cases("fixture,api", cases=".")
-def test_view_alignments(fixture, api: AnophelesIgv):
+def test_view_alignments(fixture, rng: np.random.Generator, api: AnophelesIgv):
     region = fixture.random_region_str()
-    sample = str(np.random.choice(api.sample_metadata()["sample_id"]))
+    sample = rng.choice(api.sample_metadata()["sample_id"])
     ret = api.view_alignments(region=region, sample=sample, init=False)
     # No return value to avoid cluttering notebook output.
     assert ret is None

--- a/tests/anoph/test_pca.py
+++ b/tests/anoph/test_pca.py
@@ -124,13 +124,13 @@ def case_as1_sim(as1_sim_fixture, as1_sim_api):
 
 
 @parametrize_with_cases("fixture,api", cases=".")
-def test_pca_plotting(fixture, api: AnophelesPca):
+def test_pca_plotting(fixture, rng: np.random.Generator, api: AnophelesPca):
     # Parameters for selecting input data.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
     data_params = dict(
-        region=str(np.random.choice(api.contigs)),
-        sample_sets=np.random.choice(all_sample_sets, size=2, replace=False).tolist(),
-        site_mask=np.random.choice(list(api.site_mask_ids) + [None]),
+        region=rng.choice(api.contigs),
+        sample_sets=rng.choice(all_sample_sets, 2, replace=False).tolist(),
+        site_mask=rng.choice(list(api.site_mask_ids) + [None]),
     )
     ds = api.biallelic_snp_calls(
         min_minor_ac=pca_params.min_minor_ac_default,
@@ -141,10 +141,10 @@ def test_pca_plotting(fixture, api: AnophelesPca):
     # PCA parameters.
     n_samples = ds.sizes["samples"]
     n_snps_available = ds.sizes["variants"]
-    n_snps = int(np.random.randint(4, n_snps_available + 1))
+    n_snps = rng.integers(4, n_snps_available, endpoint=True, dtype=int)
     # PC3 required for plot_pca_coords_3d()
     assert min(n_samples, n_snps) > 3
-    n_components = int(np.random.randint(3, min(n_samples, n_snps, 10) + 1))
+    n_components = rng.integers(3, min(n_samples, n_snps, 10), endpoint=True, dtype=int)
 
     # Run the PCA.
     pca_df, pca_evr = api.pca(
@@ -210,13 +210,13 @@ def test_pca_plotting(fixture, api: AnophelesPca):
 
 
 @parametrize_with_cases("fixture,api", cases=".")
-def test_pca_exclude_samples(fixture, api: AnophelesPca):
+def test_pca_exclude_samples(fixture, rng: np.random.Generator, api: AnophelesPca):
     # Parameters for selecting input data.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
     data_params = dict(
-        region=str(np.random.choice(api.contigs)),
-        sample_sets=np.random.choice(all_sample_sets, size=2, replace=False).tolist(),
-        site_mask=np.random.choice(list(api.site_mask_ids) + [None]),
+        region=rng.choice(api.contigs),
+        sample_sets=rng.choice(all_sample_sets, 2, replace=False).tolist(),
+        site_mask=rng.choice(list(api.site_mask_ids) + [None]),
     )
     ds = api.biallelic_snp_calls(
         min_minor_ac=pca_params.min_minor_ac_default,
@@ -225,17 +225,15 @@ def test_pca_exclude_samples(fixture, api: AnophelesPca):
     )
 
     # Exclusion parameters.
-    n_samples_excluded = int(np.random.randint(1, 6))
+    n_samples_excluded = rng.integers(1, 6, dtype=int)
     samples = ds["sample_id"].values.tolist()
-    exclude_samples = np.random.choice(
-        samples, size=n_samples_excluded, replace=False
-    ).tolist()
+    exclude_samples = rng.choice(samples, n_samples_excluded, replace=False).tolist()
 
     # PCA parameters.
     n_samples = ds.sizes["samples"] - n_samples_excluded
     n_snps_available = ds.sizes["variants"]
-    n_snps = int(np.random.randint(4, n_snps_available + 1))
-    n_components = int(np.random.randint(2, min(n_samples, n_snps, 10) + 1))
+    n_snps = rng.integers(4, n_snps_available, endpoint=True, dtype=int)
+    n_components = rng.integers(2, min(n_samples, n_snps, 10), endpoint=True, dtype=int)
 
     # Run the PCA.
     pca_df, pca_evr = api.pca(
@@ -273,13 +271,13 @@ def test_pca_exclude_samples(fixture, api: AnophelesPca):
 
 
 @parametrize_with_cases("fixture,api", cases=".")
-def test_pca_fit_exclude_samples(fixture, api: AnophelesPca):
+def test_pca_fit_exclude_samples(fixture, rng: np.random.Generator, api: AnophelesPca):
     # Parameters for selecting input data.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
     data_params = dict(
-        region=str(np.random.choice(api.contigs)),
-        sample_sets=np.random.choice(all_sample_sets, size=2, replace=False).tolist(),
-        site_mask=np.random.choice(list(api.site_mask_ids) + [None]),
+        region=rng.choice(api.contigs),
+        sample_sets=rng.choice(all_sample_sets, 2, replace=False).tolist(),
+        site_mask=rng.choice(list(api.site_mask_ids) + [None]),
     )
     ds = api.biallelic_snp_calls(
         min_minor_ac=pca_params.min_minor_ac_default,
@@ -288,17 +286,15 @@ def test_pca_fit_exclude_samples(fixture, api: AnophelesPca):
     )
 
     # Exclusion parameters.
-    n_samples_excluded = int(np.random.randint(1, 6))
+    n_samples_excluded = rng.integers(1, 6, dtype=int)
     samples = ds["sample_id"].values.tolist()
-    exclude_samples = np.random.choice(
-        samples, size=n_samples_excluded, replace=False
-    ).tolist()
+    exclude_samples = rng.choice(samples, n_samples_excluded, replace=False).tolist()
 
     # PCA parameters.
     n_samples = ds.sizes["samples"]
     n_snps_available = ds.sizes["variants"]
-    n_snps = int(np.random.randint(4, n_snps_available + 1))
-    n_components = int(np.random.randint(2, min(n_samples, n_snps, 10) + 1))
+    n_snps = rng.integers(4, n_snps_available, endpoint=True, dtype=int)
+    n_components = rng.integers(2, min(n_samples, n_snps, 10), endpoint=True, dtype=int)
 
     # Run the PCA.
     pca_df, pca_evr = api.pca(
@@ -430,10 +426,10 @@ def test_jitter_determinism():
     fraction = 0.1
 
     rng1 = np.random.default_rng(seed=42)
-    result1 = _jitter(a, fraction, random_state=rng1)
+    result1 = _jitter(a, fraction, rng1)
 
     rng2 = np.random.default_rng(seed=42)
-    result2 = _jitter(a, fraction, random_state=rng2)
+    result2 = _jitter(a, fraction, rng2)
 
     np.testing.assert_array_equal(result1, result2)
 
@@ -446,10 +442,10 @@ def test_jitter_different_seeds():
     fraction = 0.1
 
     rng1 = np.random.default_rng(seed=42)
-    result1 = _jitter(a, fraction, random_state=rng1)
+    result1 = _jitter(a, fraction, rng1)
 
     rng2 = np.random.default_rng(seed=99)
-    result2 = _jitter(a, fraction, random_state=rng2)
+    result2 = _jitter(a, fraction, rng2)
 
     assert not np.array_equal(result1, result2)
 
@@ -462,7 +458,7 @@ def test_jitter_no_global_rng_side_effect():
     state_before = np.random.get_state()[1].copy()
 
     rng = np.random.default_rng(seed=42)
-    _jitter(np.array([1.0, 2.0, 3.0]), 0.1, random_state=rng)
+    _jitter(np.array([1.0, 2.0, 3.0]), 0.1, rng)
 
     state_after = np.random.get_state()[1].copy()
     np.testing.assert_array_equal(state_before, state_after)

--- a/tests/anoph/test_plink_converter.py
+++ b/tests/anoph/test_plink_converter.py
@@ -121,18 +121,20 @@ def case_as1_sim(as1_sim_fixture, as1_sim_api):
 
 
 @parametrize_with_cases("fixture,api", cases=".")
-def test_plink_converter(fixture, api: PlinkConverter, tmp_path):
+def test_plink_converter(
+    fixture, rng: np.random.Generator, api: PlinkConverter, tmp_path
+):
     # Parameters for selecting input data, filtering, and converting.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
 
     data_params = dict(
-        region=str(np.random.choice(api.contigs)),
-        sample_sets=np.random.choice(all_sample_sets, size=2, replace=False).tolist(),
-        site_mask=np.random.choice(list(api.site_mask_ids) + [None]),
+        region=rng.choice(api.contigs),
+        sample_sets=rng.choice(all_sample_sets, 2, replace=False).tolist(),
+        site_mask=rng.choice(list(api.site_mask_ids) + [None]),
         min_minor_ac=1,
         max_missing_an=1,
         thin_offset=1,
-        random_seed=int(np.random.randint(1, 2001)),
+        random_seed=rng.integers(1, 2001, dtype=int),
     )
 
     # Load a ds containing the randomly generated samples and regions to get the number of available snps to subset from.
@@ -141,7 +143,7 @@ def test_plink_converter(fixture, api: PlinkConverter, tmp_path):
     )
 
     n_snps_available = ds.sizes["variants"]
-    n_snps = int(np.random.randint(1, n_snps_available + 1))
+    n_snps = rng.integers(1, n_snps_available, endpoint=True, dtype=int)
 
     # Define plink params.
     plink_params = dict(output_dir=str(tmp_path), n_snps=n_snps, **data_params)

--- a/tests/anoph/test_snp_frq.py
+++ b/tests/anoph/test_snp_frq.py
@@ -181,22 +181,24 @@ expected_impacts = [
 ]
 
 
-def random_transcript(*, api):
+def random_transcript(*, api, rng: np.random.Generator):
     df_gff = api.genome_features(attributes=["ID", "Parent"])
     df_transcripts = df_gff.query("type == 'mRNA'")
     transcript_ids = df_transcripts["ID"].dropna().to_list()
-    transcript_id = np.random.choice(transcript_ids)
+    transcript_id = rng.choice(transcript_ids)
     transcript = df_transcripts.set_index("ID").loc[transcript_id]
     return transcript
 
 
 @parametrize_with_cases("fixture,api", cases=".")
-def test_snp_effects(fixture, api: AnophelesSnpFrequencyAnalysis):
+def test_snp_effects(
+    fixture, rng: np.random.Generator, api: AnophelesSnpFrequencyAnalysis
+):
     # Pick a random transcript.
-    transcript = random_transcript(api=api)
+    transcript = random_transcript(api=api, rng=rng)
 
     # Pick a random site mask.
-    site_mask = np.random.choice(list(api.site_mask_ids) + [None])
+    site_mask = rng.choice(list(api.site_mask_ids) + [None])
 
     # Compute effects.
     df = api.snp_effects(transcript=transcript.name, site_mask=site_mask)
@@ -373,15 +375,16 @@ def check_aa_allele_frequencies(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_allele_frequencies_with_str_cohorts(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
     cohorts,
 ):
     # Pick test parameters at random.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
-    sample_sets = str(np.random.choice(all_sample_sets))
-    site_mask = np.random.choice(list(api.site_mask_ids) + [None])
-    min_cohort_size = int(np.random.randint(0, 3))
-    transcript = random_transcript(api=api)
+    sample_sets = rng.choice(all_sample_sets)
+    site_mask = rng.choice(list(api.site_mask_ids) + [None])
+    min_cohort_size = rng.integers(0, 3, dtype=int)
+    transcript = random_transcript(api=api, rng=rng)
 
     # Set up call params.
     params = dict(
@@ -452,14 +455,15 @@ def test_allele_frequencies_with_str_cohorts(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_allele_frequencies_with_min_cohort_size(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
     min_cohort_size,
 ):
     # Pick test parameters at random.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
-    sample_sets = str(np.random.choice(all_sample_sets))
-    site_mask = np.random.choice(list(api.site_mask_ids) + [None])
-    transcript = random_transcript(api=api)
+    sample_sets = rng.choice(all_sample_sets)
+    site_mask = rng.choice(list(api.site_mask_ids) + [None])
+    transcript = random_transcript(api=api, rng=rng)
     cohorts = "admin1_year"
 
     # Set up call params.
@@ -518,19 +522,18 @@ def test_allele_frequencies_with_min_cohort_size(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_allele_frequencies_with_str_cohorts_and_sample_query(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
 ):
     # Pick test parameters at random.
     sample_sets = None
-    site_mask = np.random.choice(list(api.site_mask_ids) + [None])
+    site_mask = rng.choice(list(api.site_mask_ids) + [None])
     min_cohort_size = 0
-    transcript = random_transcript(api=api)
-    cohorts = str(
-        np.random.choice(["admin1_year", "admin1_month", "admin2_year", "admin2_month"])
-    )
+    transcript = random_transcript(api=api, rng=rng)
+    cohorts = rng.choice(["admin1_year", "admin1_month", "admin2_year", "admin2_month"])
     df_samples = api.sample_metadata(sample_sets=sample_sets)
     countries = df_samples["country"].unique()
-    country = str(np.random.choice(countries))
+    country = rng.choice(countries)
     sample_query = f"country == '{country}'"
 
     # Figure out expected cohort labels.
@@ -589,19 +592,18 @@ def test_allele_frequencies_with_str_cohorts_and_sample_query(
 )
 def test_allele_frequencies_with_str_cohorts_and_sample_query_options(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
 ):
     # Pick test parameters at random.
     sample_sets = None
-    site_mask = np.random.choice(list(api.site_mask_ids) + [None])
+    site_mask = rng.choice(list(api.site_mask_ids) + [None])
     min_cohort_size = 0
-    transcript = random_transcript(api=api)
-    cohorts = str(
-        np.random.choice(["admin1_year", "admin1_month", "admin2_year", "admin2_month"])
-    )
+    transcript = random_transcript(api=api, rng=rng)
+    cohorts = rng.choice(["admin1_year", "admin1_month", "admin2_year", "admin2_month"])
     df_samples = api.sample_metadata(sample_sets=sample_sets)
     countries = df_samples["country"].unique().tolist()
-    countries_list = np.random.choice(countries, size=2, replace=False).tolist()
+    countries_list = rng.choice(countries, 2, replace=False)
     sample_query_options = {
         "local_dict": {
             "countries_list": countries_list,
@@ -666,13 +668,13 @@ def test_allele_frequencies_with_str_cohorts_and_sample_query_options(
 
 @parametrize_with_cases("fixture,api", cases=".")
 def test_allele_frequencies_with_dict_cohorts(
-    fixture, api: AnophelesSnpFrequencyAnalysis
+    fixture, rng: np.random.Generator, api: AnophelesSnpFrequencyAnalysis
 ):
     # Pick test parameters at random.
     sample_sets = None  # all sample sets
-    site_mask = np.random.choice(list(api.site_mask_ids) + [None])
-    min_cohort_size = int(np.random.randint(0, 3))
-    transcript = random_transcript(api=api)
+    site_mask = rng.choice(list(api.site_mask_ids) + [None])
+    min_cohort_size = rng.integers(0, 3, dtype=int)
+    transcript = random_transcript(api=api, rng=rng)
 
     # Create cohorts by country.
     df_samples = api.sample_metadata(sample_sets=sample_sets)
@@ -719,15 +721,16 @@ def test_allele_frequencies_with_dict_cohorts(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_allele_frequencies_without_drop_invariant(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
 ):
     # Pick test parameters at random.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
-    sample_sets = str(np.random.choice(all_sample_sets))
-    site_mask = np.random.choice(list(api.site_mask_ids) + [None])
-    min_cohort_size = int(np.random.randint(0, 3))
-    transcript = random_transcript(api=api)
-    cohorts = str(np.random.choice(["admin1_year", "admin2_month", "country"]))
+    sample_sets = rng.choice(all_sample_sets)
+    site_mask = rng.choice(list(api.site_mask_ids) + [None])
+    min_cohort_size = rng.integers(0, 3, dtype=int)
+    transcript = random_transcript(api=api, rng=rng)
+    cohorts = rng.choice(["admin1_year", "admin2_month", "country"])
 
     # Figure out expected cohort labels.
     df_samples = api.sample_metadata(sample_sets=sample_sets)
@@ -775,15 +778,16 @@ def test_allele_frequencies_without_drop_invariant(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_allele_frequencies_without_effects(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
 ):
     # Pick test parameters at random.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
-    sample_sets = str(np.random.choice(all_sample_sets))
-    site_mask = np.random.choice(list(api.site_mask_ids) + [None])
-    min_cohort_size = int(np.random.randint(0, 3))
-    transcript = random_transcript(api=api)
-    cohorts = str(np.random.choice(["admin1_year", "admin2_month", "country"]))
+    sample_sets = rng.choice(all_sample_sets)
+    site_mask = rng.choice(list(api.site_mask_ids) + [None])
+    min_cohort_size = rng.integers(0, 3, dtype=int)
+    transcript = random_transcript(api=api, rng=rng)
+    cohorts = rng.choice(["admin1_year", "admin2_month", "country"])
 
     # Figure out expected cohort labels.
     df_samples = api.sample_metadata(sample_sets=sample_sets)
@@ -857,14 +861,15 @@ def test_allele_frequencies_without_effects(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_allele_frequencies_with_bad_transcript(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
 ):
     # Pick test parameters at random.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
-    sample_sets = str(np.random.choice(all_sample_sets))
-    site_mask = np.random.choice(list(api.site_mask_ids) + [None])
-    min_cohort_size = int(np.random.randint(0, 3))
-    cohorts = str(np.random.choice(["admin1_year", "admin2_month", "country"]))
+    sample_sets = rng.choice(all_sample_sets)
+    site_mask = rng.choice(list(api.site_mask_ids) + [None])
+    min_cohort_size = rng.integers(0, 3, dtype=int)
+    cohorts = rng.choice(["admin1_year", "admin2_month", "country"])
 
     # Set up call params.
     params = dict(
@@ -884,14 +889,15 @@ def test_allele_frequencies_with_bad_transcript(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_allele_frequencies_with_region(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
 ):
     # Pick test parameters at random.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
-    sample_sets = str(np.random.choice(all_sample_sets))
-    site_mask = np.random.choice(list(api.site_mask_ids) + [None])
-    min_cohort_size = int(np.random.randint(0, 3))
-    cohorts = str(np.random.choice(["admin1_year", "admin2_month", "country"]))
+    sample_sets = rng.choice(all_sample_sets)
+    site_mask = rng.choice(list(api.site_mask_ids) + [None])
+    min_cohort_size = rng.integers(0, 3, dtype=int)
+    cohorts = rng.choice(["admin1_year", "admin2_month", "country"])
     # This should work, as long as effects=False - i.e., can get frequencies
     # for any genome region.
     transcript = fixture.random_region_str(region_size=500)
@@ -942,15 +948,16 @@ def test_allele_frequencies_with_region(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_allele_frequencies_with_dup_samples(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
 ):
     # Pick test parameters at random.
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
-    sample_set = str(np.random.choice(all_sample_sets))
-    site_mask = np.random.choice(list(api.site_mask_ids) + [None])
-    min_cohort_size = int(np.random.randint(0, 3))
-    transcript = random_transcript(api=api)
-    cohorts = str(np.random.choice(["admin1_year", "admin2_month", "country"]))
+    sample_set = rng.choice(all_sample_sets)
+    site_mask = rng.choice(list(api.site_mask_ids) + [None])
+    min_cohort_size = rng.integers(0, 3, dtype=int)
+    transcript = random_transcript(api=api, rng=rng)
+    cohorts = rng.choice(["admin1_year", "admin2_month", "country"])
 
     # Set up call params.
     params = dict(
@@ -983,6 +990,7 @@ def test_allele_frequencies_with_dup_samples(
 def check_snp_allele_frequencies_advanced(
     *,
     api: AnophelesSnpFrequencyAnalysis,
+    rng: np.random.Generator,
     transcript=None,
     area_by="admin1_iso",
     period_by="year",
@@ -996,22 +1004,22 @@ def check_snp_allele_frequencies_advanced(
 ):
     # Pick test parameters at random.
     if transcript is None:
-        transcript = random_transcript(api=api).name
+        transcript = random_transcript(api=api, rng=rng).name
     if area_by is None:
-        area_by = str(np.random.choice(["country", "admin1_iso", "admin2_name"]))
+        area_by = rng.choice(["country", "admin1_iso", "admin2_name"])
     if period_by is None:
-        period_by = str(np.random.choice(["year", "quarter", "month", "random_year"]))
+        period_by = rng.choice(["year", "quarter", "month", "random_year"])
     if sample_sets is None:
         all_sample_sets = api.sample_sets()["sample_set"].to_list()
-        sample_sets = str(np.random.choice(all_sample_sets))
+        sample_sets = rng.choice(all_sample_sets)
     if min_cohort_size is None:
-        min_cohort_size = int(np.random.randint(0, 3))
+        min_cohort_size = rng.integers(0, 3, dtype=int)
     if site_mask is None:
-        site_mask = np.random.choice(list(api.site_mask_ids) + [None])
+        site_mask = rng.choice(list(api.site_mask_ids) + [None])
 
     if period_by == "random_year":
         # Add a random_year column to the sample metadata, if there isn't already.
-        api = add_random_year(api=api)
+        api = add_random_year(api=api, rng=rng)
 
     # Run function under test.
     try:
@@ -1037,8 +1045,8 @@ def check_snp_allele_frequencies_advanced(
     # Check the result.
     assert isinstance(ds, xr.Dataset)
     check_plot_frequencies_time_series(api, ds)
-    check_plot_frequencies_time_series_with_taxa(api, ds)
-    check_plot_frequencies_time_series_with_areas(api, ds)
+    check_plot_frequencies_time_series_with_taxa(api, ds, rng)
+    check_plot_frequencies_time_series_with_areas(api, ds, rng)
     check_plot_frequencies_interactive_map(api, ds)
     assert set(ds.dims) == {"cohorts", "variants"}
 
@@ -1191,6 +1199,7 @@ def check_snp_allele_frequencies_advanced(
 def check_aa_allele_frequencies_advanced(
     *,
     api: AnophelesSnpFrequencyAnalysis,
+    rng: np.random.Generator,
     transcript=None,
     area_by="admin1_iso",
     period_by="year",
@@ -1203,20 +1212,20 @@ def check_aa_allele_frequencies_advanced(
 ):
     # Pick test parameters at random.
     if transcript is None:
-        transcript = random_transcript(api=api).name
+        transcript = random_transcript(api=api, rng=rng).name
     if area_by is None:
-        area_by = str(np.random.choice(["country", "admin1_iso", "admin2_name"]))
+        area_by = rng.choice(["country", "admin1_iso", "admin2_name"])
     if period_by is None:
-        period_by = str(np.random.choice(["year", "quarter", "month", "random_year"]))
+        period_by = rng.choice(["year", "quarter", "month", "random_year"])
     if sample_sets is None:
         all_sample_sets = api.sample_sets()["sample_set"].to_list()
-        sample_sets = str(np.random.choice(all_sample_sets))
+        sample_sets = rng.choice(all_sample_sets)
     if min_cohort_size is None:
-        min_cohort_size = int(np.random.randint(0, 3))
+        min_cohort_size = rng.integers(0, 3, dtype=int)
 
     if period_by == "random_year":
         # Add a random_year column to the sample metadata, if there isn't already.
-        api = add_random_year(api=api)
+        api = add_random_year(api=api, rng=rng)
 
     # Run function under test.
     try:
@@ -1241,8 +1250,8 @@ def check_aa_allele_frequencies_advanced(
     # Check the result.
     assert isinstance(ds, xr.Dataset)
     check_plot_frequencies_time_series(api, ds)
-    check_plot_frequencies_time_series_with_taxa(api, ds)
-    check_plot_frequencies_time_series_with_areas(api, ds)
+    check_plot_frequencies_time_series_with_taxa(api, ds, rng)
+    check_plot_frequencies_time_series_with_areas(api, ds, rng)
     check_plot_frequencies_interactive_map(api, ds)
     assert set(ds.dims) == {"cohorts", "variants"}
 
@@ -1391,15 +1400,18 @@ def check_aa_allele_frequencies_advanced(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_allele_frequencies_advanced_with_area_by(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
     area_by,
 ):
     check_snp_allele_frequencies_advanced(
         api=api,
+        rng=rng,
         area_by=area_by,
     )
     check_aa_allele_frequencies_advanced(
         api=api,
+        rng=rng,
         area_by=area_by,
     )
 
@@ -1408,15 +1420,18 @@ def test_allele_frequencies_advanced_with_area_by(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_allele_frequencies_advanced_with_period_by(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
     period_by,
 ):
     check_snp_allele_frequencies_advanced(
         api=api,
+        rng=rng,
         period_by=period_by,
     )
     check_aa_allele_frequencies_advanced(
         api=api,
+        rng=rng,
         period_by=period_by,
     )
 
@@ -1424,22 +1439,25 @@ def test_allele_frequencies_advanced_with_period_by(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_allele_frequencies_advanced_with_sample_query(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
 ):
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
     df_samples = api.sample_metadata(sample_sets=all_sample_sets)
     countries = df_samples["country"].unique()
-    country = str(np.random.choice(countries))
+    country = rng.choice(countries)
     sample_query = f"country == '{country}'"
 
     check_snp_allele_frequencies_advanced(
         api=api,
+        rng=rng,
         sample_sets=all_sample_sets,
         sample_query=sample_query,
         min_cohort_size=0,
     )
     check_aa_allele_frequencies_advanced(
         api=api,
+        rng=rng,
         sample_sets=all_sample_sets,
         sample_query=sample_query,
         min_cohort_size=0,
@@ -1451,12 +1469,13 @@ def test_allele_frequencies_advanced_with_sample_query(
 )
 def test_allele_frequencies_advanced_with_sample_query_options(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
 ):
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
     df_samples = api.sample_metadata(sample_sets=all_sample_sets)
     countries = df_samples["country"].unique().tolist()
-    countries_list = np.random.choice(countries, size=2, replace=False).tolist()
+    countries_list = rng.choice(countries, 2, replace=False)
     sample_query_options = {
         "local_dict": {
             "countries_list": countries_list,
@@ -1466,6 +1485,7 @@ def test_allele_frequencies_advanced_with_sample_query_options(
 
     check_snp_allele_frequencies_advanced(
         api=api,
+        rng=rng,
         sample_sets=all_sample_sets,
         sample_query=sample_query,
         sample_query_options=sample_query_options,
@@ -1473,6 +1493,7 @@ def test_allele_frequencies_advanced_with_sample_query_options(
     )
     check_aa_allele_frequencies_advanced(
         api=api,
+        rng=rng,
         sample_sets=all_sample_sets,
         sample_query=sample_query,
         sample_query_options=sample_query_options,
@@ -1486,19 +1507,21 @@ def test_allele_frequencies_advanced_with_sample_query_options(
 )
 def test_allele_frequencies_advanced_with_min_cohort_size(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
     min_cohort_size,
 ):
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
     area_by = "admin1_iso"
     period_by = "year"
-    transcript = random_transcript(api=api).name
+    transcript = random_transcript(api=api, rng=rng).name
 
     if min_cohort_size <= 10:
         # Expect this to find at least one cohort, so go ahead with full
         # checks.
         check_snp_allele_frequencies_advanced(
             api=api,
+            rng=rng,
             transcript=transcript,
             sample_sets=all_sample_sets,
             min_cohort_size=min_cohort_size,
@@ -1507,6 +1530,7 @@ def test_allele_frequencies_advanced_with_min_cohort_size(
         )
         check_aa_allele_frequencies_advanced(
             api=api,
+            rng=rng,
             transcript=transcript,
             sample_sets=all_sample_sets,
             min_cohort_size=min_cohort_size,
@@ -1536,17 +1560,19 @@ def test_allele_frequencies_advanced_with_min_cohort_size(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_allele_frequencies_advanced_with_variant_query(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
 ):
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
     area_by = "admin1_iso"
     period_by = "year"
-    transcript = random_transcript(api=api).name
+    transcript = random_transcript(api=api, rng=rng).name
 
     # Test a query that should succeed.
     variant_query = "effect == 'NON_SYNONYMOUS_CODING'"
     check_snp_allele_frequencies_advanced(
         api=api,
+        rng=rng,
         transcript=transcript,
         sample_sets=all_sample_sets,
         area_by=area_by,
@@ -1555,6 +1581,7 @@ def test_allele_frequencies_advanced_with_variant_query(
     )
     check_aa_allele_frequencies_advanced(
         api=api,
+        rng=rng,
         transcript=transcript,
         sample_sets=all_sample_sets,
         area_by=area_by,
@@ -1591,15 +1618,18 @@ def test_allele_frequencies_advanced_with_variant_query(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_allele_frequencies_advanced_with_nobs_mode(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
     nobs_mode,
 ):
     check_snp_allele_frequencies_advanced(
         api=api,
+        rng=rng,
         nobs_mode=nobs_mode,
     )
     check_aa_allele_frequencies_advanced(
         api=api,
+        rng=rng,
         nobs_mode=nobs_mode,
     )
 
@@ -1607,17 +1637,20 @@ def test_allele_frequencies_advanced_with_nobs_mode(
 @parametrize_with_cases("fixture,api", cases=".")
 def test_allele_frequencies_advanced_with_dup_samples(
     fixture,
+    rng: np.random.Generator,
     api: AnophelesSnpFrequencyAnalysis,
 ):
     all_sample_sets = api.sample_sets()["sample_set"].to_list()
-    sample_set = str(np.random.choice(all_sample_sets))
+    sample_set = rng.choice(all_sample_sets)
     sample_sets = [sample_set, sample_set]
 
     check_snp_allele_frequencies_advanced(
         api=api,
+        rng=rng,
         sample_sets=sample_sets,
     )
     check_aa_allele_frequencies_advanced(
         api=api,
+        rng=rng,
         sample_sets=sample_sets,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,15 @@
-import numpy as np
+import secrets
 import pytest
 
+GLOBAL_SEED = secrets.randbits(128)
 
-@pytest.fixture(autouse=True, scope="session")
-def seed_random():
-    np.random.seed(42)
+
+# The report header needs to be in the top-level
+# conftest.py in order to be printed in all cases.
+def pytest_report_header(config):
+    return f"global seed: {GLOBAL_SEED}"
+
+
+@pytest.fixture(scope="session", name="global_seed")
+def global_seed_fixture():
+    return GLOBAL_SEED


### PR DESCRIPTION
This converts about half of the pytest functions so their random number generation is reproducible. The name of the pytest function test case is used to seed the RNG to ensure all functions generate independent random numbers. There are a few instances where the Numpy RNG has slightly different behaviour than the Python ones (e.g. `random.randint()` includes the endpoint by default while `rng.integers()` does not), so that had to be adapted. There are also a few cases where the numpy types have to be cast to Python types to make the type checker happy (e.g. `np.int64 -> int`), otherwise it's quite similar. 

This was tested by trying to reproduce [this flaky test failure](https://github.com/malariagen/malariagen-data-python/actions/runs/22472053182/job/65090921923). After about 140 trials I was able to find a random seed that caused the crash (325228949307297790525745584766237006555 in this case), and I am able to reliably reproduce this crash with that seed. Once this is finished the next job will be debugging that.

There are a lot of functions to convert, so the other half will be done in another PR since this one is large already.

While testing this I noticed that the global seed wasn't being printed in the workflow logs, even though it is when you run tests individually. Apparently this is because the seed needs to be printed from the top-level `conftest.py`, otherwise it won't get picked up when running `pytest -v tests`. Anyway, I rearranged some of the files so it works now.