### PR TITLE
fix: decode URL-escaped local filesystem paths in _init_filesystem

### DIFF
--- a/malariagen_data/util.py
+++ b/malariagen_data/util.py
@@ -11,7 +11,7 @@ from functools import wraps
 from inspect import getcallargs
 from textwrap import dedent, fill
 from typing import IO, Dict, Hashable, List, Mapping, Optional, Tuple, Union, Callable
-from urllib.parse import unquote_plus
+from urllib.parse import unquote, unquote_plus
 from numpy.testing import assert_allclose, assert_array_equal
 
 try:
@@ -493,6 +493,16 @@ def _init_filesystem(url, **kwargs):
 
     # Process the URL using fsspec.
     fs, path = url_to_fs(url, **storage_options)
+
+    # Decode URL-escaped local paths (e.g., spaces as %20) before opening files.
+    # fsspec does not consistently decode local file paths across versions.
+    protocol = fs.protocol
+    if isinstance(protocol, tuple):
+        is_local_filesystem = "file" in protocol or "local" in protocol
+    else:
+        is_local_filesystem = protocol in ("file", "local")
+    if is_local_filesystem:
+        path = unquote(path)
 
     # Path compatibility, fsspec/gcsfs behaviour varies between versions.
     while path.endswith("/"):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from malariagen_data.util import _init_filesystem
+
+
+def test_init_filesystem_decodes_local_file_uri_path(tmp_path: Path):
+    root = tmp_path / "dir with spaces and apostrophe's"
+    root.mkdir()
+    config_path = root / "v3-config.json"
+    config_path.write_text("{}", encoding="utf-8")
+
+    fs, path = _init_filesystem(root.as_uri())
+
+    with fs.open(f"{path}/v3-config.json") as f:
+        assert f.read() == b"{}"


### PR DESCRIPTION
## Summary
- decode URL-escaped local paths returned from `url_to_fs()` when protocol is local (`file`/`local`)
- add a regression test that uses a `file://` URI containing spaces and apostrophes

Closes #1056.

## Validation
- `poetry run pytest -q tests/test_util.py tests/anoph/test_aim_data.py::test_aim_variants[gambcolu_vs_arab]`