### PR TITLE
feat: add VCF export functionality resolves #1054

### DIFF
--- a/malariagen_data/anoph/to_vcf.py
+++ b/malariagen_data/anoph/to_vcf.py
@@ -99,51 +99,33 @@ class VcfExporter(
             chunks=chunks,
         )
 
-        # Compute genotype array from dask
-        with self._dask_progress("Computing genotype array"):
-            gt_array = allel.GenotypeDaskArray(ds_snps["call_genotype"].data).compute()
-
         # Extract variant info
         with self._spinner("Preparing VCF output data"):
             chrom = ds_snps["variant_contig"].values
             pos = ds_snps["variant_position"].values
             alleles = ds_snps["variant_allele"].values
             ref = alleles[:, 0]
-            alt = alleles[:, 1]
+            alt = alleles[:, 1:]
             sample_ids = ds_snps["sample_id"].values
+
+        # Compute genotype array from dask
+        with self._dask_progress("Computing genotype array"):
+            gt_array = allel.GenotypeDaskArray(ds_snps["call_genotype"].data).compute()
 
         # Build output directory if it doesn't exist
         os.makedirs(output_dir, exist_ok=True)
 
-        # Write VCF file
+        # Write VCF file using scikit-allel's optimized writer
         with self._spinner("Writing VCF file"):
-            with open(vcf_file_path, "w") as vcf_out:
-                # Write VCF header
-                vcf_out.write("##fileformat=VCFv4.1\n")
-                vcf_out.write(
-                    '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+            with open(vcf_file_path, "w", encoding="utf-8") as f:
+                allel.write_vcf(
+                    f,
+                    chrom=chrom,
+                    pos=pos,
+                    ref=ref,
+                    alt=alt,
+                    samples=sample_ids,
+                    calldata_2d={"GT": gt_array},
                 )
-                # Write column header line
-                sample_cols = "\t".join(sample_ids)
-                vcf_out.write(
-                    f"#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t{sample_cols}\n"
-                )
-
-                # Write one line per variant
-                n_variants = len(pos)
-                for i in range(n_variants):
-                    gt_row = gt_array[i]  # shape: (n_samples, ploidy)
-                    # Convert genotype calls to VCF GT string e.g. "0/1"
-                    gt_strings = []
-                    for sample_gt in gt_row:
-                        if -1 in sample_gt:
-                            gt_strings.append("./.")
-                        else:
-                            gt_strings.append("/".join(str(a) for a in sample_gt))
-                    gt_col = "\t".join(gt_strings)
-                    vcf_out.write(
-                        f"{chrom[i]}\t{pos[i]}\t.\t{ref[i]}\t{alt[i]}"
-                        f"\t.\tPASS\t.\tGT\t{gt_col}\n"
-                    )
 
         return vcf_file_path

--- a/malariagen_data/anoph/to_vcf.py
+++ b/malariagen_data/anoph/to_vcf.py
@@ -1,12 +1,12 @@
 from typing import Optional
 import os
-import allel  # type: ignore
 
 from .snp_data import AnophelesSnpData
 from . import base_params
 from . import plink_params
 from . import pca_params
 from numpydoc_decorator import doc  # type: ignore
+import dask.array as da
 
 
 class VcfExporter(
@@ -27,10 +27,10 @@ class VcfExporter(
         """,
         extended_summary="""
             This function writes biallelic SNPs to the VCF (Variant Call Format) file format.
-            It enables subsetting to specific regions (`region`), selecting specific sample sets,
+            It enables subsetting to specific regions (region), selecting specific sample sets,
             or lists of samples, randomly downsampling sites, and specifying filters based on
-            missing data and minimum minor allele count (see the docs for `biallelic_snp_calls`
-            for more information). The `overwrite` parameter, set to true, will enable overwrite
+            missing data and minimum minor allele count (see the docs for biallelic_snp_calls
+            for more information). The overwrite parameter, set to true, will enable overwrite
             of data with the same SNP selection parameter values.
         """,
         returns="""
@@ -38,10 +38,14 @@ class VcfExporter(
         """,
         notes="""
             This computation may take some time to run, depending on your computing
-            environment. Unless the `overwrite` parameter is set to `True`, results will be
+            environment. Unless the overwrite parameter is set to True, results will be
             returned from a previous computation, if available. The output follows the VCF 4.1
             specification and can be used directly with tools such as bcftools, GATK, and R
             packages like VariantAnnotation.
+
+            Genotype data is written chunk-by-chunk directly from Dask arrays, so the full
+            genotype matrix is never loaded into memory at once. This is important for
+            large datasets where VCF files can be very large.
         """,
     )
     def biallelic_snps_to_vcf(
@@ -77,7 +81,7 @@ class VcfExporter(
             f".{max_missing_an}.{thin_offset}.vcf"
         )
 
-        # Check to see if file exists and if overwrite is set to false, return existing file
+        # Return existing file if overwrite is False
         if os.path.exists(vcf_file_path):
             if not overwrite:
                 return vcf_file_path
@@ -99,33 +103,64 @@ class VcfExporter(
             chunks=chunks,
         )
 
-        # Extract variant info
-        with self._spinner("Preparing VCF output data"):
+        # Extract variant and sample metadata (small arrays, safe to load fully)
+        with self._spinner("Preparing VCF metadata"):
             chrom = ds_snps["variant_contig"].values
             pos = ds_snps["variant_position"].values
             alleles = ds_snps["variant_allele"].values
             ref = alleles[:, 0]
-            alt = alleles[:, 1:]
+            alt = alleles[:, 1]
             sample_ids = ds_snps["sample_id"].values
 
-        # Compute genotype array from dask
-        with self._dask_progress("Computing genotype array"):
-            gt_array = allel.GenotypeDaskArray(ds_snps["call_genotype"].data).compute()
-
-        # Build output directory if it doesn't exist
+        # Build output directory if it does not exist
         os.makedirs(output_dir, exist_ok=True)
 
-        # Write VCF file using scikit-allel's optimized writer
+        # Write VCF file using chunked iteration over Dask arrays.
+        # This avoids loading the full genotype matrix into memory at once,
+        # which is critical given the potential size of VCF files.
+        gt_dask = ds_snps["call_genotype"].data  # shape: (variants, samples, ploidy)
+        gt_chunks = da.rechunk(gt_dask, chunks=(1000, -1, -1))
+
         with self._spinner("Writing VCF file"):
             with open(vcf_file_path, "w", encoding="utf-8") as f:
-                allel.write_vcf(
-                    f,
-                    chrom=chrom,
-                    pos=pos,
-                    ref=ref,
-                    alt=alt,
-                    samples=sample_ids,
-                    calldata_2d={"GT": gt_array},
+                # Write VCF header
+                f.write("##fileformat=VCFv4.1\n")
+                f.write('##FILTER=<ID=PASS,Description="All filters passed">\n')
+                f.write(
+                    '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
                 )
+                f.write(
+                    "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t"
+                    + "\t".join(str(s) for s in sample_ids)
+                    + "\n"
+                )
+
+                # Iterate chunk by chunk - 1000 variants at a time
+                chunk_start = 0
+                for chunk in gt_chunks.blocks:
+                    gt_block = chunk.compute()
+                    chunk_size = gt_block.shape[0]
+                    for i in range(chunk_size):
+                        v = chunk_start + i
+                        gt_strings = []
+                        for s in range(gt_block.shape[1]):
+                            a0 = gt_block[i, s, 0]
+                            a1 = gt_block[i, s, 1]
+                            if a0 < 0 or a1 < 0:
+                                gt_strings.append("./.")
+                            else:
+                                gt_strings.append(f"{a0}/{a1}")
+                        ref_val = ref[v]
+                        alt_val = alt[v]
+                        if isinstance(ref_val, bytes):
+                            ref_val = ref_val.decode()
+                        if isinstance(alt_val, bytes):
+                            alt_val = alt_val.decode()
+                        f.write(
+                            f"{chrom[v]}\t{pos[v]}\t.\t{ref_val}\t{alt_val}\t.\tPASS\t.\tGT\t"
+                            + "\t".join(gt_strings)
+                            + "\n"
+                        )
+                    chunk_start += chunk_size
 
         return vcf_file_path

--- a/malariagen_data/anoph/to_vcf.py
+++ b/malariagen_data/anoph/to_vcf.py
@@ -1,0 +1,152 @@
+from typing import Optional
+import os
+import allel  # type: ignore
+import numpy as np
+
+from .snp_data import AnophelesSnpData
+from . import base_params
+from . import plink_params
+from . import pca_params
+from numpydoc_decorator import doc  # type: ignore
+
+
+class VcfExporter(
+    AnophelesSnpData,
+):
+    def __init__(
+        self,
+        **kwargs,
+    ):
+        # N.B., this class is designed to work cooperatively, and
+        # so it's important that any remaining parameters are passed
+        # to the superclass constructor.
+        super().__init__(**kwargs)
+
+    @doc(
+        summary="""
+            Write Anopheles biallelic SNP data to VCF file format.
+        """,
+        extended_summary="""
+            This function writes biallelic SNPs to the VCF (Variant Call Format) file format.
+            It enables subsetting to specific regions (`region`), selecting specific sample sets,
+            or lists of samples, randomly downsampling sites, and specifying filters based on
+            missing data and minimum minor allele count (see the docs for `biallelic_snp_calls`
+            for more information). The `overwrite` parameter, set to true, will enable overwrite
+            of data with the same SNP selection parameter values.
+        """,
+        returns="""
+            Path to the output VCF file.
+        """,
+        notes="""
+            This computation may take some time to run, depending on your computing
+            environment. Unless the `overwrite` parameter is set to `True`, results will be
+            returned from a previous computation, if available. The output follows the VCF 4.1
+            specification and can be used directly with tools such as bcftools, GATK, and R
+            packages like VariantAnnotation.
+        """,
+    )
+    def biallelic_snps_to_vcf(
+        self,
+        output_dir: plink_params.output_dir,
+        region: base_params.regions,
+        n_snps: base_params.n_snps,
+        overwrite: plink_params.overwrite = False,
+        thin_offset: base_params.thin_offset = 0,
+        sample_sets: Optional[base_params.sample_sets] = None,
+        sample_query: Optional[base_params.sample_query] = None,
+        sample_query_options: Optional[base_params.sample_query_options] = None,
+        sample_indices: Optional[base_params.sample_indices] = None,
+        site_mask: Optional[base_params.site_mask] = base_params.DEFAULT,
+        min_minor_ac: Optional[
+            base_params.min_minor_ac
+        ] = pca_params.min_minor_ac_default,
+        max_missing_an: Optional[
+            base_params.max_missing_an
+        ] = pca_params.max_missing_an_default,
+        random_seed: base_params.random_seed = 42,
+        inline_array: base_params.inline_array = base_params.inline_array_default,
+        chunks: base_params.chunks = base_params.native_chunks,
+    ):
+        # Check that either sample_query xor sample_indices are provided.
+        base_params._validate_sample_selection_params(
+            sample_query=sample_query, sample_indices=sample_indices
+        )
+
+        # Define output file path
+        vcf_file_path = (
+            f"{output_dir}/{region}.{n_snps}.{min_minor_ac}"
+            f".{max_missing_an}.{thin_offset}.vcf"
+        )
+
+        # Check to see if file exists and if overwrite is set to false, return existing file
+        if os.path.exists(vcf_file_path):
+            if not overwrite:
+                return vcf_file_path
+
+        # Get biallelic SNPs
+        ds_snps = self.biallelic_snp_calls(
+            region=region,
+            sample_sets=sample_sets,
+            sample_query=sample_query,
+            sample_query_options=sample_query_options,
+            sample_indices=sample_indices,
+            site_mask=site_mask,
+            min_minor_ac=min_minor_ac,
+            max_missing_an=max_missing_an,
+            n_snps=n_snps,
+            thin_offset=thin_offset,
+            random_seed=random_seed,
+            inline_array=inline_array,
+            chunks=chunks,
+        )
+
+        # Compute genotype array from dask
+        with self._dask_progress("Computing genotype array"):
+            gt_array = allel.GenotypeDaskArray(
+                ds_snps["call_genotype"].data
+            ).compute()
+
+        # Extract variant info
+        with self._spinner("Preparing VCF output data"):
+            chrom = ds_snps["variant_contig"].values
+            pos = ds_snps["variant_position"].values
+            alleles = ds_snps["variant_allele"].values
+            ref = alleles[:, 0]
+            alt = alleles[:, 1]
+            sample_ids = ds_snps["sample_id"].values
+
+        # Build output directory if it doesn't exist
+        os.makedirs(output_dir, exist_ok=True)
+
+        # Write VCF file
+        with self._spinner("Writing VCF file"):
+            with open(vcf_file_path, "w") as vcf_out:
+                # Write VCF header
+                vcf_out.write("##fileformat=VCFv4.1\n")
+                vcf_out.write(
+                    '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+                )
+                # Write column header line
+                sample_cols = "\t".join(sample_ids)
+                vcf_out.write(
+                    f"#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t{sample_cols}\n"
+                )
+
+                # Write one line per variant
+                n_variants = len(pos)
+                for i in range(n_variants):
+                    gt_row = gt_array[i]  # shape: (n_samples, ploidy)
+                    # Convert genotype calls to VCF GT string e.g. "0/1"
+                    gt_strings = []
+                    for sample_gt in gt_row:
+                        if -1 in sample_gt:
+                            gt_strings.append("./.")
+                        else:
+                            gt_strings.append("/".join(str(a) for a in sample_gt))
+                    gt_col = "\t".join(gt_strings)
+                    vcf_out.write(
+                        f"{chrom[i]}\t{pos[i]}\t.\t{ref[i]}\t{alt[i]}"
+                        f"\t.\tPASS\t.\tGT\t{gt_col}\n"
+                    )
+
+        return vcf_file_path

--- a/malariagen_data/anoph/to_vcf.py
+++ b/malariagen_data/anoph/to_vcf.py
@@ -105,7 +105,9 @@ class VcfExporter(
 
         # Extract variant and sample metadata (small arrays, safe to load fully)
         with self._spinner("Preparing VCF metadata"):
-            chrom = ds_snps["variant_contig"].values
+            # variant_contig contains integer indices, convert to contig name strings
+            contig_indices = ds_snps["variant_contig"].values
+            chrom = [self.contigs[i] for i in contig_indices]
             pos = ds_snps["variant_position"].values
             alleles = ds_snps["variant_allele"].values
             ref = alleles[:, 0]

--- a/malariagen_data/anoph/to_vcf.py
+++ b/malariagen_data/anoph/to_vcf.py
@@ -1,7 +1,6 @@
 from typing import Optional
 import os
 import allel  # type: ignore
-import numpy as np
 
 from .snp_data import AnophelesSnpData
 from . import base_params
@@ -102,9 +101,7 @@ class VcfExporter(
 
         # Compute genotype array from dask
         with self._dask_progress("Computing genotype array"):
-            gt_array = allel.GenotypeDaskArray(
-                ds_snps["call_genotype"].data
-            ).compute()
+            gt_array = allel.GenotypeDaskArray(ds_snps["call_genotype"].data).compute()
 
         # Extract variant info
         with self._spinner("Preparing VCF output data"):

--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -36,7 +36,7 @@ from .anoph.distance import AnophelesDistanceAnalysis
 from .anoph.sample_metadata import AnophelesSampleMetadata
 from .anoph.snp_data import AnophelesSnpData
 from .anoph.to_plink import PlinkConverter
-from .anoph.to_vcf import VcfExporter    
+from .anoph.to_vcf import VcfExporter
 from .anoph.g123 import AnophelesG123Analysis
 from .anoph.fst import AnophelesFstAnalysis
 from .anoph.h12 import AnophelesH12Analysis
@@ -89,7 +89,7 @@ class AnophelesDataResource(
     AnophelesDistanceAnalysis,
     AnophelesPca,
     PlinkConverter,
-    VcfExporter,   
+    VcfExporter,
     AnophelesIgv,
     AnophelesKaryotypeAnalysis,
     AnophelesAimData,

--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -36,6 +36,7 @@ from .anoph.distance import AnophelesDistanceAnalysis
 from .anoph.sample_metadata import AnophelesSampleMetadata
 from .anoph.snp_data import AnophelesSnpData
 from .anoph.to_plink import PlinkConverter
+from .anoph.to_vcf import VcfExporter    
 from .anoph.g123 import AnophelesG123Analysis
 from .anoph.fst import AnophelesFstAnalysis
 from .anoph.h12 import AnophelesH12Analysis
@@ -88,6 +89,7 @@ class AnophelesDataResource(
     AnophelesDistanceAnalysis,
     AnophelesPca,
     PlinkConverter,
+    VcfExporter,   
     AnophelesIgv,
     AnophelesKaryotypeAnalysis,
     AnophelesAimData,


### PR DESCRIPTION
## Summary
Adds `biallelic_snps_to_vcf()` method to export Anopheles biallelic 
SNP data to VCF (Variant Call Format) file format, enabling use with 
external tools such as bcftools, GATK, and R packages like 
VariantAnnotation.

## Changes
- Added `VcfExporter` mixin class in `malariagen_data/anoph/to_vcf.py`
- Integrated `VcfExporter` into `AnophelesDataResource` in `anopheles.py`
- Follows existing `PlinkConverter` mixin architecture pattern
- Output follows VCF 4.1 specification

## Approach
- Reuses existing biallelic_snp_calls() API
- Genotype data written chunk-by-chunk (1000 variants at a time) directly from Dask arrays — the full genotype matrix is never loaded into memory
- Writes spec-compliant VCF 4.1 manually with proper GT fields, FILTER, INFO and FORMAT columns
- allel.write_vcf() was evaluated but does not support sample/genotype data, so a manual writer was used instead
- Supports same filtering parameters as biallelic_snps_to_plink()

## Why VCF?
VCF is the most widely used format in genomics and is supported by:
- bcftools and samtools
- GATK pipelines  
- R packages (VariantAnnotation, vcfR)
- ADMIXTURE and other population genetics tools

## TODO
- [ ] Add unit tests