### PR TITLE
Optimize quarter column computation using vectorized NumPy operations

### DIFF
--- a/malariagen_data/anoph/sample_metadata.py
+++ b/malariagen_data/anoph/sample_metadata.py
@@ -181,9 +181,10 @@ class AnophelesSampleMetadata(AnophelesBase):
             df["release"] = release
 
             # Derive a quarter column from month.
-            df["quarter"] = df.apply(
-                lambda row: ((row.month - 1) // 3) + 1 if row.month > 0 else -1,
-                axis="columns",
+            df["quarter"] = np.where(
+                df["month"] > 0,
+                ((df["month"] - 1) // 3) + 1,
+                -1
             )
 
             # Add study columns.


### PR DESCRIPTION
This PR replaces the row-wise pandas "apply()" used to compute the "quarter"
column with a vectorized NumPy implementation.

Previous implementation:

df["quarter"] = df.apply(
    lambda row: ((row.month - 1) // 3) + 1 if row.month > 0 else -1,
    axis="columns",
)

Row-wise "apply()" loops through rows in Python and can be slow for large datasets.

The new implementation uses NumPy vectorization:

df["quarter"] = np.where(
    df["month"] > 0,
    ((df["month"] - 1) // 3) + 1,
    -1
)

This improves performance and follows pandas best practices.