### PR TITLE
Fixed lookup sample errors

### DIFF
--- a/malariagen_data/anoph/sample_metadata.py
+++ b/malariagen_data/anoph/sample_metadata.py
@@ -1162,10 +1162,28 @@ class AnophelesSampleMetadata(AnophelesBase):
         df_samples = self.sample_metadata(sample_sets=sample_set).set_index("sample_id")
         sample_rec = None
         if isinstance(sample, str):
-            sample_rec = df_samples.loc[sample]
+            try:
+                sample_rec = df_samples.loc[sample]
+            except KeyError:
+                available_sample_sets = (
+                    f" in sample set '{sample_set}'" if sample_set is not None else ""
+                )
+                raise ValueError(
+                    f"Sample '{sample}' not found{available_sample_sets}. "
+                    f"Available samples can be found by calling sample_metadata()."
+                )
         else:
             assert isinstance(sample, int)
-            sample_rec = df_samples.iloc[sample]
+            try:
+                sample_rec = df_samples.iloc[sample]
+            except IndexError:
+                available_sample_sets = (
+                    f" in sample set '{sample_set}'" if sample_set is not None else ""
+                )
+                raise ValueError(
+                    f"Sample index {sample} is out of bounds{available_sample_sets}. "
+                    f"Valid indices are 0 to {len(df_samples) - 1}."
+                )
         return sample_rec
 
     @_check_types

--- a/tests/anoph/test_sample_metadata.py
+++ b/tests/anoph/test_sample_metadata.py
@@ -1250,6 +1250,29 @@ def test_lookup_sample(fixture, api):
     assert sorted(list(sample_rec_by_sample_loc_set.index)) == sorted_expected_fields
 
 
+@parametrize_with_cases("fixture,api", cases=".")
+def test_lookup_sample_errors(fixture, api):
+    import pytest
+
+    # Test with non-existent sample ID
+    with pytest.raises(ValueError, match=r"Sample 'FAKE123' not found"):
+        api.lookup_sample("FAKE123")
+
+    # Test with non-existent sample ID in specific sample set
+    df_samples = api.sample_metadata()
+    sample_set = df_samples["sample_set"].iloc[0]  # Get first sample set
+    with pytest.raises(ValueError, match=r"Sample 'FAKE123' not found in sample set"):
+        api.lookup_sample("FAKE123", sample_set)
+
+    # Test with out-of-bounds index
+    with pytest.raises(ValueError, match=r"Sample index -1 is out of bounds"):
+        api.lookup_sample(-1)
+
+    # Test with out-of-bounds index in specific sample set
+    with pytest.raises(ValueError, match=r"Sample index 99999 is out of bounds in sample set"):
+        api.lookup_sample(99999, sample_set)
+
+
 @parametrize_with_cases(
     "fixture,api", cases=".", filter=~ft.has_tag("amin1")
 )  # N.B. exclude amin1 as there is no sex call data.


### PR DESCRIPTION
This PR enhances the `lookup_sample()` method in `malariagen_data/anoph/sample_metadata.py` to provide more informative error messages when invalid sample IDs or indices are provided.

**Changes:**
- Catch `KeyError` and `IndexError` exceptions and raise `ValueError` with helpful messages instead.
- For non-existent sample IDs: "Sample 'ID' not found. Available samples can be found by calling sample_metadata()."
- For invalid indices: "Sample index X is out of bounds. Valid indices are 0 to Y."
- Added comprehensive tests in `tests/anoph/test_sample_metadata.py` to verify error handling.

**Motivation:**
The original raw `KeyError` was unhelpful for users. This improves the developer experience by providing actionable feedback.

Fixes #[1078].