### PR TITLE
docs: fix distance_sort parameter description in tree_params.py

### DIFF
--- a/malariagen_data/anoph/tree_params.py
+++ b/malariagen_data/anoph/tree_params.py
@@ -13,7 +13,8 @@ count_sort: TypeAlias = Annotated[
 distance_sort: TypeAlias = Annotated[
     bool,
     """
-    If True, for each node n, if True, the child with the minimum distance between
-    is plotted first. Note distance_sort and count_sort cannot both be True.
+    If True, for each node n, the child with the minimum distance between its
+    direct descendants is plotted first. Note distance_sort and count_sort
+    cannot both be True.
     """,
 ]


### PR DESCRIPTION
## What

Fixed the `distance_sort` parameter description in `malariagen_data/anoph/tree_params.py`.

## Why

The current description has two issues:

1. "if True" appears twice: *"If True, for each node n, if True, the child..."*
2. "distance between" is incomplete — it doesn't say between what.

## Fix

- Removed the duplicated "if True"
- Clarified that the distance is between the node's direct descendants, consistent with scipy's `dendrogram(distance_sort)` documentation.

The `count_sort` description directly above was already correct and served as a reference for the fix.