### PR TITLE
fix: use `is not None` for region boundary checks in _subset_genome_sequence_region

### DIFF
--- a/malariagen_data/plasmodium.py
+++ b/malariagen_data/plasmodium.py
@@ -232,17 +232,17 @@ class PlasmodiumDataResource:
     def _subset_genome_sequence_region(
         self, genome, region, inline_array=True, chunks="native"
     ):
-        """Sebset reference genome sequence."""
+        """Subset reference genome sequence."""
         region = self._resolve_region(region)
         z = genome[region.contig]
 
         d = _da_from_zarr(z, inline_array=inline_array, chunks=chunks)
 
-        if region.start:
+        if region.start is not None:
             slice_start = region.start - 1
         else:
             slice_start = None
-        if region.end:
+        if region.end is not None:
             slice_stop = region.end
         else:
             slice_stop = None


### PR DESCRIPTION
## What

Fixed region boundary checks in `_subset_genome_sequence_region()` in `plasmodium.py`,
and fixed a typo in the docstring ("Sebset" → "Subset").

## Why

The current code uses `if region.start:` and `if region.end:` to check whether
region boundaries are set. In Python, `0` is falsy, so when a user queries a
region starting at position 0, the slicing is silently skipped and the full
contig is returned instead.

This is the same class of bug as described in #940 for the Anopheles side
(`snp_data.py` / `hap_data.py`), but this instance in the Plasmodium code
was not covered there.

## Fix

Replaced `if region.start:` with `if region.start is not None:` (and same
for `region.end`) to correctly distinguish between "no boundary specified"
(None) and "boundary is zero" (0).