### PR TITLE
fix: preserve sample_query_options during cohort normalization

### DIFF
--- a/malariagen_data/anoph/base.py
+++ b/malariagen_data/anoph/base.py
@@ -948,6 +948,18 @@ class AnophelesBase:
 
         return prepped_sample_query
 
+    def _prep_sample_query_options(
+        self,
+        *,
+        sample_query_options: Optional[base_params.sample_query_options],
+    ) -> dict:
+        """Normalise pandas query options while keeping python engine as default."""
+
+        prepped_sample_query_options = dict(sample_query_options or {})
+        prepped_sample_query_options.setdefault("engine", "python")
+
+        return prepped_sample_query_options
+
     def _filter_sample_dataset(
         self,
         *,
@@ -963,9 +975,10 @@ class AnophelesBase:
         # Determine which samples match the sample query.
         if sample_query != "":
             # Use the python engine in order to support extension array dtypes, e.g. Float64, Int64, boolean.
-            loc_samples = df_samples.eval(
-                sample_query, **sample_query_options, engine="python"
+            sample_query_options = self._prep_sample_query_options(
+                sample_query_options=sample_query_options
             )
+            loc_samples = df_samples.eval(sample_query, **sample_query_options)
         else:
             loc_samples = pd.Series(True, index=df_samples.index)
 

--- a/malariagen_data/anoph/sample_metadata.py
+++ b/malariagen_data/anoph/sample_metadata.py
@@ -780,11 +780,11 @@ class AnophelesSampleMetadata(AnophelesBase):
         # Note: this might have been internally modified, e.g. `is_surveillance == True`.
         if prepared_sample_query is not None:
             # Assume a pandas query string.
-            sample_query_options = sample_query_options or {}
-            # Use the python engine in order to support extension array dtypes, e.g. Float64, Int64, boolean.
-            df_samples = df_samples.query(
-                prepared_sample_query, **sample_query_options, engine="python"
+            sample_query_options = self._prep_sample_query_options(
+                sample_query_options=sample_query_options
             )
+            # Use the python engine in order to support extension array dtypes, e.g. Float64, Int64, boolean.
+            df_samples = df_samples.query(prepared_sample_query, **sample_query_options)
             df_samples = df_samples.reset_index(drop=True)
 
         # Apply the sample_indices, if there are any.
@@ -1115,14 +1115,16 @@ class AnophelesSampleMetadata(AnophelesBase):
             df_samples = self.sample_metadata(sample_sets=prepared_sample_sets)
 
             # Default the sample_query_options to an empty dict.
-            sample_query_options = sample_query_options or {}
+            sample_query_options = self._prep_sample_query_options(
+                sample_query_options=sample_query_options
+            )
 
             # Use the python engine in order to support extension array dtypes, e.g. Float64, Int64, boolean.
             # Get the Pandas Series as a NumPy array of Boolean values.
             # Note: if `prepared_sample_query` is an internal query, this will select all samples,
             # since `sample_metadata` should have already applied the internal query.
             loc_samples = df_samples.eval(
-                prepared_sample_query, **sample_query_options, engine="python"
+                prepared_sample_query, **sample_query_options
             ).values
 
             # Convert the sample indices to a list.
@@ -1459,7 +1461,9 @@ class AnophelesSampleMetadata(AnophelesBase):
         cohort_queries_checked = dict()
         for cohort_label, cohort_query in cohort_queries.items():
             df_cohort_samples = self.sample_metadata(
-                sample_sets=sample_sets, sample_query=cohort_query
+                sample_sets=sample_sets,
+                sample_query=cohort_query,
+                sample_query_options=sample_query_options,
             )
             n_samples = len(df_cohort_samples)
             if min_cohort_size is not None:

--- a/tests/anoph/test_fst.py
+++ b/tests/anoph/test_fst.py
@@ -226,9 +226,14 @@ def check_pairwise_average_fst(api: AnophelesFstAnalysis, fst_params):
     # Check cohort pairs are correct.
     sample_sets = fst_params["sample_sets"]
     sample_query = fst_params.get("sample_query")
+    sample_query_options = fst_params.get("sample_query_options")
     cohorts = fst_params["cohorts"]
     min_cohort_size = fst_params["min_cohort_size"]
-    df_samples = api.sample_metadata(sample_sets=sample_sets, sample_query=sample_query)
+    df_samples = api.sample_metadata(
+        sample_sets=sample_sets,
+        sample_query=sample_query,
+        sample_query_options=sample_query_options,
+    )
     if isinstance(cohorts, str):
         if "cohort_" + cohorts in df_samples:
             cohort_column = "cohort_" + cohorts
@@ -344,6 +349,33 @@ def test_pairwise_average_fst_with_sample_query(fixture, api: AnophelesFstAnalys
         site_mask=site_mask,
         min_cohort_size=1,
         n_jack=random.randint(10, 200),
+    )
+
+    # Run checks.
+    check_pairwise_average_fst(api=api, fst_params=fst_params)
+
+
+@parametrize_with_cases("fixture,api", cases=".")
+def test_pairwise_average_fst_with_sample_query_local_dict(
+    fixture, api: AnophelesFstAnalysis
+):
+    # Set up test parameters.
+    all_sample_sets = api.sample_sets()["sample_set"].to_list()
+    df_samples = api.sample_metadata(sample_sets=all_sample_sets)
+    country_counts = df_samples["country"].value_counts()
+    countries_list = sorted(country_counts[country_counts >= 2].index.to_list()[:2])
+    assert len(countries_list) == 2
+
+    fst_params = dict(
+        region=random.choice(api.contigs),
+        cohorts="country",
+        sample_sets=all_sample_sets,
+        sample_query="country in @countries_list",
+        sample_query_options={"local_dict": {"countries_list": countries_list}},
+        site_mask=random.choice(api.site_mask_ids),
+        cohort_size=2,
+        min_cohort_size=2,
+        n_jack=random.randint(10, 50),
     )
 
     # Run checks.

--- a/tests/anoph/test_h12.py
+++ b/tests/anoph/test_h12.py
@@ -360,6 +360,31 @@ def test_h12_gwss_multi_param_forwarding(fixture, api: AnophelesH12Analysis):
     assert isinstance(fig, bokeh.models.GridPlot)
 
 
+@parametrize_with_cases("fixture,api", cases=".")
+def test_h12_gwss_multi_with_sample_query_local_dict(
+    fixture, api: AnophelesH12Analysis
+):
+    """Verify local_dict-backed sample queries work in multi-cohort H12 plots."""
+    all_sample_sets = api.sample_sets()["sample_set"].to_list()
+    df_samples = api.sample_metadata(sample_sets=all_sample_sets)
+    country_counts = df_samples["country"].value_counts()
+    countries_list = sorted(country_counts[country_counts >= 2].index.to_list()[:2])
+    assert len(countries_list) == 2
+
+    h12_params = dict(
+        contig=random.choice(api.contigs),
+        cohorts="country",
+        sample_sets=all_sample_sets,
+        window_size=200,
+        cohort_size=2,
+        min_cohort_size=2,
+        sample_query="country in @countries_list",
+        sample_query_options={"local_dict": {"countries_list": countries_list}},
+    )
+
+    check_h12_gwss_multi(api=api, h12_params=h12_params)
+
+
 def test_garud_h12_empty_window():
     import numpy as np
     from malariagen_data.anoph.h12 import _garud_h12

--- a/tests/anoph/test_sample_metadata.py
+++ b/tests/anoph/test_sample_metadata.py
@@ -842,6 +842,28 @@ def test_sample_metadata_with_query(ag3_sim_api):
     assert (df["country"] == "Burkina Faso").all()
 
 
+def test_sample_metadata_with_query_options(ag3_sim_api):
+    df_all = ag3_sim_api.sample_metadata()
+    countries_list = sorted(df_all["country"].dropna().unique().tolist()[:2])
+    df = ag3_sim_api.sample_metadata(
+        sample_query="country in @countries_list",
+        sample_query_options={
+            "engine": "python",
+            "local_dict": {"countries_list": countries_list},
+        },
+    )
+    validate_metadata(
+        df,
+        sample_metadata_expected_columns(
+            has_aims=True,
+            has_cohorts_by_quarter=True,
+            has_sequence_qc=True,
+            ordered_contigs=sorted(ag3_sim_api.config["CONTIGS"]),
+        ),
+    )
+    assert sorted(df["country"].dropna().unique().tolist()) == countries_list
+
+
 def test_sample_metadata_with_indices(ag3_sim_api):
     df_all = ag3_sim_api.sample_metadata()
     query = "country == 'Burkina Faso'"


### PR DESCRIPTION
## Summary
Before this change, `sample_query_options` could still be lost inside shared cohort normalisation even after the recent caller-level forwarding fixes. Any multi-cohort path that rebuilt cohort queries and then rechecked cohort sizes would fail for valid parameterised pandas queries such as `country in @countries_list`.

After this change, cohort normalisation preserves the full query context, and the shared query helpers now treat `engine="python"` as a default rather than forcing it as a duplicate keyword.

Closes #1100.

## Why this matters
This is a framework-level correctness fix, not just a surface patch:
- `pairwise_average_fst()` was still broken for `local_dict`-backed filters because `_setup_cohort_queries()` re-applied the combined cohort query without `sample_query_options`.
- Multi-cohort H12 plotting had the same underlying problem for variable-backed sample filters.
- Once query options are forwarded correctly, `sample_metadata()` and `_filter_sample_dataset()` must also accept an explicit `engine` option without raising `TypeError`.

The net effect is that the public `sample_query_options` contract now behaves consistently across direct metadata selection and higher-level cohort analyses.

## Exact changes
- add `_prep_sample_query_options()` in `AnophelesBase` to preserve user-supplied query context while defaulting the engine to `python`
- use that helper in shared query-evaluation paths instead of passing `engine="python"` as a duplicate keyword
- pass `sample_query_options` through `_setup_cohort_queries()` when validating derived cohort queries
- add regressions for:
  - direct `sample_metadata()` queries using both `engine` and `local_dict`
  - `pairwise_average_fst()` with `local_dict`-backed `sample_query`
  - multi-cohort H12 plotting with `local_dict`-backed `sample_query`

## Tests run
- `ruff check malariagen_data/anoph/base.py malariagen_data/anoph/sample_metadata.py tests/anoph/test_fst.py tests/anoph/test_h12.py tests/anoph/test_sample_metadata.py`
- `pytest tests/anoph/test_h12.py tests/anoph/test_fst.py -q`
- `pytest tests/anoph/test_sample_metadata.py -k 'sample_metadata_with_query or sample_metadata_with_indices or query_options' -q`

