### PR TITLE
Fix pipx link and update CI version statement in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ This package provides Python tools for accessing and analyzing genomic data from
 
 You'll need:
 
-- [pipx](https://python-poetry.org/) for installing Python tools
+- [pipx](https://pipx.pypa.io/) for installing Python tools
 - [git](https://git-scm.com/) for version control
 
 Both of these can be installed using your distribution's package manager or [Homebrew](https://brew.sh/) on Mac.
@@ -230,7 +230,7 @@ poetry run pytest -v tests --typeguard-packages=malariagen_data,malariagen_data.
 ### Review process
 
 - PRs require approval from a project maintainer
-- CI tests must pass (pytest on Python 3.10 with NumPy 1.26.4)
+- CI tests must pass (pytest on Python 3.10, 3.11, and 3.12 with NumPy 2.0.2 and the latest allowed version `<2.1`)
 - Address review feedback by pushing new commits to your branch
 - Once approved, a maintainer will merge your PR
 


### PR DESCRIPTION
Fixes #1105

## What changed
- Corrected the `pipx` prerequisite link, which pointed to the Poetry homepage instead of the pipx docs
- Updated the CI description in the review section to reflect the current test matrix

## Why
`CONTRIBUTING.md` line 15 linked `pipx` to `https://python-poetry.org/` (the Poetry site).  
`CONTRIBUTING.md` line 233 said CI runs on "Python 3.10 with NumPy 1.26.4", but `.github/workflows/tests.yml` shows the matrix now tests Python 3.10, 3.11, and 3.12 with NumPy 2.0.2 and the latest allowed `<2.1`.

Both are contributor-facing, so stale information makes onboarding harder.

## Testing
Documentation-only change. No code was modified.