### PR TITLE
fix: replace truthiness checks with `is not None` in PlasmodiumDataResource._subset_genome_sequence_region

### DIFF
--- a/malariagen_data/plasmodium.py
+++ b/malariagen_data/plasmodium.py
@@ -232,17 +232,17 @@ class PlasmodiumDataResource:
     def _subset_genome_sequence_region(
         self, genome, region, inline_array=True, chunks="native"
     ):
-        """Sebset reference genome sequence."""
+        """Subset reference genome sequence."""
         region = self._resolve_region(region)
         z = genome[region.contig]
 
         d = _da_from_zarr(z, inline_array=inline_array, chunks=chunks)
 
-        if region.start:
+        if region.start is not None:
             slice_start = region.start - 1
         else:
             slice_start = None
-        if region.end:
+        if region.end is not None:
             slice_stop = region.end
         else:
             slice_stop = None


### PR DESCRIPTION
## What problem does this solve?

`_subset_genome_sequence_region()` in `plasmodium.py` uses truthiness checks (`if region.start:` / `if region.end:`) to decide whether to slice the genome sequence. Because Python evaluates `0` as falsy, specifying `region.start = 0` silently skips slicing and returns the entire contig instead of the requested sub-region.

This is the same class of bug as #940, but in the Plasmodium codebase (`PlasmodiumDataResource`) which is not covered by that issue.

## How does it solve it?

Replace the truthiness checks with explicit `None` checks:

```diff
-        if region.start:
+        if region.start is not None:
             slice_start = region.start - 1
         else:
             slice_start = None
-        if region.end:
+        if region.end is not None:
             slice_stop = region.end
         else:
             slice_stop = None
```

This correctly distinguishes between "no boundary specified" (`None`) and "boundary is zero" (`0`).

Also fixes a docstring typo: `Sebset` → `Subset`.

## Relevant issues

Related: #940

## Testing done

- Pre-commit hooks (ruff lint, ruff format, trailing whitespace, end of files) all pass ✅

## Breaking changes

None. This fix restores the expected behavior for edge-case inputs that were previously silently mishandled.
Closes  #1108