### PR TITLE
Prevent PLINK filename collisions by hashing content-affecting selection parameters

### DIFF
--- a/malariagen_data/anoph/to_plink.py
+++ b/malariagen_data/anoph/to_plink.py
@@ -5,7 +5,7 @@ import numpy as np
 import os
 import bed_reader
 
-from ..util import _dask_compress_dataset
+from ..util import _dask_compress_dataset, _hash_params
 from .snp_data import AnophelesSnpData
 from . import base_params
 from . import plink_params
@@ -75,8 +75,25 @@ class PlinkConverter(
             sample_query=sample_query, sample_indices=sample_indices
         )
 
+        # Include a compact hash for selection parameters that affect output
+        # content but are not suitable to place directly in the filename.
+        params_hash, _ = _hash_params(
+            dict(
+                sample_sets=sample_sets,
+                sample_query=sample_query,
+                sample_query_options=sample_query_options,
+                sample_indices=sample_indices,
+                site_mask=site_mask,
+                random_seed=random_seed,
+            )
+        )
+        params_hash_short = params_hash[:8]
+
         # Define output files
-        plink_file_path = f"{output_dir}/{region}.{n_snps}.{min_minor_ac}.{max_missing_an}.{thin_offset}"
+        plink_file_path = (
+            f"{output_dir}/{region}.{n_snps}.{min_minor_ac}.{max_missing_an}"
+            f".{thin_offset}.{params_hash_short}"
+        )
 
         bed_file_path = f"{plink_file_path}.bed"
 

--- a/tests/anoph/test_plink_converter.py
+++ b/tests/anoph/test_plink_converter.py
@@ -124,11 +124,9 @@ def test_plink_converter(fixture, api: PlinkConverter, tmp_path):
     plink_params = dict(output_dir=str(tmp_path), n_snps=n_snps, **data_params)
 
     # Make the plink files.
-    api.biallelic_snps_to_plink(**plink_params)
+    file_path = api.biallelic_snps_to_plink(**plink_params)
 
     # Test to see if bed, bim, fam output files exist.
-    file_path = f"{str(tmp_path)}/{plink_params['region']}.{plink_params['n_snps']}.{plink_params['min_minor_ac']}.{plink_params['max_missing_an']}.{plink_params['thin_offset']}"
-
     assert os.path.exists(f"{file_path}.bed")
     assert os.path.exists(f"{file_path}.bim")
     assert os.path.exists(f"{file_path}.fam")


### PR DESCRIPTION
## Issue Summary
`biallelic_snps_to_plink` generates a filename prefix from a subset of arguments (region and SNP filtering parameters), while other arguments that also change exported content were excluded from the path. This could cause two semantically different export requests to resolve to the same .bed/.bim/.fam prefix and overwrite or reuse incorrect files.

## Proposed solution

Include a deterministic hash in the PLINK filename prefix derived from the parameters that affect output content but are not suitable to place directly in filenames.

1. Build a dictionary from the excluded content-affecting parameters. (`sample_sets` , `sample_query` etc)
2. Hash that dictionary deterministically using the existing `_hash_params()` utility.
3. Append a short prefix of the hash, the first 8 hex characters, to the filename prefix.

This keeps filenames short while preventing collisions from distinct sample-selection inputs.
## Implementation
- Modified `biallelic_snps_to_plink()` in `to_plink.py `to hash excluded parameters and append the 8-character suffix to the filename.
- Updated `test_plink_converter.py `to use the returned file prefix from `biallelic_snps_to_plink()` rather than reconstructing the filename pattern, ensuring tests validate the actual behavior.

## Why hashing is preferable

- `sample_sets` can be long lists.
- `sample_query` and `sample_query_options` can contain arbitrary expressions and structured values.
- Directly embedding those values into filenames would be verbose and fragile.
- The repository already has `_hash_params()` for deterministic parameter hashing, so this follows an existing internal pattern.

## Proposed filename change

Current style:

```text
{output_dir}/{region}.{n_snps}.{min_minor_ac}.{max_missing_an}.{thin_offset}
```

Proposed style:

```text
{output_dir}/{region}.{n_snps}.{min_minor_ac}.{max_missing_an}.{thin_offset}.{param_hash}
```


## Validation
- All ruff checks passed on modified files.
- PLINK converter tests (2 test cases) passed.
- Full non-integration test suite passed (993 passed, 4 skipped).


## Compatibility note

This will change the output filenames generated by these methods. That is intentional, because the current naming scheme can alias distinct exports to the same path.

closes #1113 