### PR TITLE
Fix: use af1 instead of ag3 in Af1 notebook section

### DIFF
--- a/notebooks/plot_haplotypes_frequencies.ipynb
+++ b/notebooks/plot_haplotypes_frequencies.ipynb
@@ -102,7 +102,7 @@
     "    sample_sets=[\"1232-VO-KE-OCHOMO-VMF00044\"],\n",
     "    min_cohort_size=10,\n",
     ")\n",
-    "ag3.plot_frequencies_time_series(hap_xr)"
+    "af1.plot_frequencies_time_series(hap_xr)"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Fix a small inconsistency in `notebooks/plot_haplotypes_frequencies.ipynb` where the Af1 section calls `plot_frequencies_time_series` on `ag3` instead of `af1`.

## Change

Replace:

```python
ag3.plot_frequencies_time_series(hap_xr)
```

with:

```python
af1.plot_frequencies_time_series(hap_xr)
```

This improves consistency in the Af1 section of the notebook and avoids potential confusion for readers.


Closes #1117 
