### PR TITLE
docs: fix pipx documentation link in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ This package provides Python tools for accessing and analyzing genomic data from
 
 You'll need:
 
-- [pipx](https://python-poetry.org/) for installing Python tools
+- [pipx](https://pipx.pypa.io/) for installing Python tools
 - [git](https://git-scm.com/) for version control
 
 Both of these can be installed using your distribution's package manager or [Homebrew](https://brew.sh/) on Mac.


### PR DESCRIPTION
Fix the documentation link for pipx in CONTRIBUTING.md.
The previous link pointed to the Poetry website instead of the official pipx documentation.

Change

Update:

[pipx](https://python-poetry.org/)

to:

[pipx](https://pipx.pypa.io/)

This ensures contributors are directed to the correct pipx documentation.

Closes #1120 
