### PR TITLE
# Feat: Add `get_metadata_schema` Helper for Sample Metadata Introspection

### DIFF
--- a/malariagen_data/anoph/sample_metadata.py
+++ b/malariagen_data/anoph/sample_metadata.py
@@ -847,7 +847,7 @@ class AnophelesSampleMetadata(AnophelesBase):
                 schema[col] = {"type": "boolean", "values": [True, False]}
             else:
                 schema[col] = {"type": "other"}
-                
+
         return schema
 
     @_check_types


### PR DESCRIPTION
## Description

### The Problem
Currently, when constructing a `sample_query` to filter dataset metadata or analysis methods (like PCA or Diversity calculations), users (or programmatic clients like an LLM) have no straightforward programmatic way to know what columns are available or what the possible valid values are (e.g., discovering all unique `country` or `taxon` values).

### The Solution
This PR introduces a small, non-breaking helper method `get_metadata_schema()` to the `AnophelesSampleMetadata` mixin class. It programmatically introspects the sample metadata dataframe and exposes a dictionary of the schema.

It automatically categorizes columns by parsing `df.columns` and `df.dtypes` to build an intelligent dictionary mapping:

- **Low-cardinality Categoricals (Strings/Objects with ≤ 100 unique values):** Returns the `type` as `"categorical"` and enumerates the possible `"values"` (e.g., for `taxon`, `country`).
- **High-cardinality Strings:** Returns `"type": "string"`.
- **Numeric columns (Int/Float):** Returns `"type": "numeric"` and calculates the `"min"` and `"max"` bounds (e.g., for `year`).
- **Booleans:** Returns `"type": "boolean"` and `"values": [True, False]`.

Closes #1123 

## Example Usage

```python
import malariagen_data

ag3 = malariagen_data.Ag3()
schema = ag3.get_metadata_schema(sample_sets="AG1000G-UG")

print(schema["country"])
# Output: {'type': 'categorical', 'values': ['Uganda']}

print(schema["year"])
# Output: {'type': 'numeric', 'min': 2012, 'max': 2012}