### PR TITLE
chore: remove duplicate cache constant definitions in ag3.py and af1.py

### DIFF
--- a/malariagen_data/af1.py
+++ b/malariagen_data/af1.py
@@ -13,8 +13,7 @@ GCS_DEFAULT_PUBLIC_URL = "gs://vo_anoph_temp_us_central1/vo_afun_release/"
 GCS_REGION_URLS = {
     "us-central1": "gs://vo_afun_release_master_us_central1",
 }
-XPEHH_GWSS_CACHE_NAME = "af1_xpehh_gwss_v1"
-IHS_GWSS_CACHE_NAME = "af1_ihs_gwss_v1"
+
 
 TAXON_PALETTE = px.colors.qualitative.Plotly
 TAXON_COLORS = {

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -17,8 +17,7 @@ GCS_DEFAULT_PUBLIC_URL = "gs://vo_anoph_temp_us_central1/vo_agam_release/"
 GCS_REGION_URLS = {
     "us-central1": "gs://vo_agam_release_master_us_central1",
 }
-XPEHH_GWSS_CACHE_NAME = "ag3_xpehh_gwss_v1"
-IHS_GWSS_CACHE_NAME = "ag3_ihs_gwss_v1"
+
 VIRTUAL_CONTIGS = {
     "2RL": ("2R", "2L"),
     "3RL": ("3R", "3L"),


### PR DESCRIPTION
This PR cleans up a minor redundancy in ag3.py and af1.py. The constants XPEHH_GWSS_CACHE_NAME and IHS_GWSS_CACHE_NAME were being defined twice in the same file. It appears this was a minor oversight leftover from the recent cache harmonization updates in #901. I have removed the duplicate definitions to keep the namespace clean.