### PR TITLE
docs: expand docstrings in amino_acid_distance, util, and anopheles

### DIFF
--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -202,27 +202,6 @@ class AnophelesDataResource(
         self, *, cohort_label, ac, n_jack, confidence_level
     ):
 
-        """Compute diversity statistics for a cohort using block jackknife resampling.
-
-        Parameters
-        ----------
-        cohort_label : str
-            Label identifying the cohort under study.
-        ac : array-like
-            Allele counts array of shape (n_sites, n_alleles).
-        n_jack : int
-            Number of jackknife blocks to use for resampling.
-        confidence_level : float
-            Confidence level for interval estimation (e.g., 0.95).
-
-        Returns
-        -------
-        dict
-            Dictionary containing the following keys for each statistic
-            (theta_pi, theta_w, tajima_d): the raw value, jackknife estimate,
-            bias, standard error, confidence interval error, lower and upper
-            confidence interval bounds. Also contains the cohort label.
-        """
         debug = self._log.debug
 
         debug("set up for diversity calculations")

--- a/malariagen_data/util.py
+++ b/malariagen_data/util.py
@@ -862,40 +862,14 @@ def _value_error(
 
 
 def _hash_params(params):
-    """Hash function parameters to a compact identifier for caching.
-
-    Parameters
-    ----------
-    params : dict
-        Dictionary of function parameters to hash.
-
-    Returns
-    -------
-    h : str
-        MD5 hex digest of the serialised parameters.
-    s : str
-        JSON string representation of the parameters.
-    """
+    """Helper function to hash function parameters."""
     s = json.dumps(params, sort_keys=True, indent=4)
     h = hashlib.md5(s.encode()).hexdigest()
     return h, s
 
 
 def _jitter(a, fraction):
-    """Jitter data by adding random noise scaled to the data range.
-
-    Parameters
-    ----------
-    a : ndarray
-        Array of values to jitter.
-    fraction : float
-        Fraction of the data range to use as the noise scale.
-
-    Returns
-    -------
-    ndarray
-        Jittered array with same shape as input.
-    """
+    """Jitter data in `a` using the fraction `f`."""
     r = a.max() - a.min()
     return a + fraction * np.random.uniform(-r, r, a.shape)
 
@@ -1607,22 +1581,8 @@ def _hash_columns(x):
 
 
 def _haplotype_frequencies(h):
-    """Compute haplotype frequencies from a haplotype array.
-
-    Parameters
-    ----------
-    h : array-like
-        2D array of haplotypes with shape (n_variants, n_samples).
-
-    Returns
-    -------
-    freqs : dict
-        Mapping of haplotype hash to frequency.
-    counts : dict
-        Mapping of haplotype hash to count.
-    nobs : dict
-        Mapping of haplotype hash to total number of observations.
-    """
+    """Compute haplotype frequencies, returning a dictionary that maps
+    haplotype hash values to frequencies."""
     n = h.shape[1]
     hashes = _hash_columns(np.asarray(h))
     count = Counter(hashes)


### PR DESCRIPTION
## Summary

This PR expands and improves docstrings across three files to make the 
codebase more accessible and easier to understand for new contributors 
and users.

## Changes

### `malariagen_data/amino_acid_distance.py`
- Added module-level docstring describing the purpose of the file
- Expanded docstring for `grantham_score()` with Parameters and Returns sections
- Expanded docstring for `sneath_dist()` with Parameters and Returns sections

### `malariagen_data/util.py`
- Expanded docstring for `_jitter()` with Parameters and Returns sections
- Expanded docstring for `_hash_params()` with Parameters and Returns sections
- Expanded docstring for `_haplotype_frequencies()` with Parameters and Returns sections

### `malariagen_data/anopheles.py`
- Added full docstring to `_block_jackknife_cohort_diversity_stats()` 
  describing its parameters, and return value

## Motivation

Several internal functions lacked sufficient documentation, making it 
harder for new contributors to understand the codebase. These changes 
follow the existing numpydoc style used throughout the project.