### PR TITLE
fix: improve error handling for invalid pandas queries in _locate_cohorts()

### DIFF
--- a/malariagen_data/anoph/sample_metadata.py
+++ b/malariagen_data/anoph/sample_metadata.py
@@ -1839,7 +1839,12 @@ def _locate_cohorts(*, cohorts, data, min_cohort_size):
         # to pandas queries.
 
         for coh, query in cohorts.items():
-            loc_coh = data.eval(query).values
+            try:
+                loc_coh = data.eval(query).values
+            except Exception as e:
+                raise ValueError(
+                    f"Invalid query for cohort {coh!r}: {query!r}. Error: {e}"
+                ) from e
             coh_dict[coh] = loc_coh
 
     else:


### PR DESCRIPTION
## 1. SUMMARY

This PR improves error handling in `_locate_cohorts()` when `cohorts` is a dict of pandas queries. Invalid queries now raise a clear `ValueError` instead of exposing raw pandas errors.

Changes are in `malariagen_data/anoph/sample_metadata.py`.

---

## 2. FIX

**Before**

```python
loc_coh = data.eval(query).values
```

**After**

```python
try:
    loc_coh = data.eval(query).values
except Exception as e:
    raise ValueError(
        f"Invalid query for cohort {coh!r}: {query!r}. Error: {e}"
    ) from e
```

---

## 3. VERIFICATION

Passing a cohort query with a missing column (e.g. `age_group`) now raises a clean `ValueError` that clearly shows which cohort and query failed, instead of a raw pandas traceback.
