### PR TITLE
Improve error handling in _parse_metadata_paths

### DIFF
--- a/malariagen_data/anoph/sample_metadata.py
+++ b/malariagen_data/anoph/sample_metadata.py
@@ -144,6 +144,11 @@ class AnophelesSampleMetadata(AnophelesBase):
         for sample_set in sample_sets:
             path = file_paths[sample_set]
             data = files[path]
+            if isinstance(data, Exception):
+                raise RuntimeError(
+                    f"Failed to load metadata for sample set '{sample_set}' at path '{path}'. "
+                    f"Original error: {data}"
+                )
             df = parse_metadata_func(sample_set, data)
             dfs.append(df)
 


### PR DESCRIPTION
### Summary

This PR improves error handling in `_parse_metadata_paths` by providing clearer and more informative error messages when metadata loading fails.

### Motivation

While exploring the code, I noticed that exceptions returned during file loading are passed directly to parsing functions. This can lead to unclear or indirect errors, making debugging harder.

### Changes

- Added explicit handling for exceptions when reading metadata files
- Raised a `RuntimeError` with:
  - sample set name
  - file path
  - original error

### Example

Instead of a generic failure, users will now see:

Failed to load metadata for sample set 'XYZ' at path '...'. Original error: ...

### Notes

This improves debuggability and user experience without changing the existing API behavior.