### PR TITLE
Fix: classify in-frame complex variants (MNP + INDEL) as INFRAME_COMPLEX_VARIANT

### DIFF
--- a/malariagen_data/veff.py
+++ b/malariagen_data/veff.py
@@ -431,9 +431,9 @@ def _get_within_cds_effect(ann, base_effect, cds, cdss):
             effect = base_effect._replace(effect="CODON_CHANGE", impact="MODERATE")
 
         else:
-            # TODO in-frame complex variation (MNP + INDEL)
+            # in-frame complex variation (MNP + INDEL)
             effect = base_effect._replace(
-                effect="TODO in-frame complex variation (MNP + INDEL)", impact="UNKNOWN"
+                effect="INFRAME_COMPLEX_VARIANT", impact="MODERATE"
             )
 
     return effect


### PR DESCRIPTION
## Summary
This PR replaces the placeholder effect for in-frame complex variants (MNP + INDEL) in `_get_within_cds_effect` with a proper classification.

## Changes
- Replaced:
  effect="TODO in-frame complex variation (MNP + INDEL)", impact="UNKNOWN"

- With:
  effect="INFRAME_COMPLEX_VARIANT", impact="MODERATE"

## Why this change?
- Improves completeness of variant annotation
- Provides meaningful and standard effect classification
- Ensures consistency with other in-frame variant types

## Impact
In-frame complex variants are now correctly labeled with a MODERATE impact instead of UNKNOWN, improving downstream analysis and interpretability.

## Testing
- Existing tests pass successfully
- (Optional) Add test cases for in-frame complex variants in future

Closes #1180

Github: @vinitjain2005