### PR TITLE
Docs: Add type hints and examples to cross_metadata docstring

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -338,7 +338,7 @@ class Ag3(AnophelesDataResource):
         """
         return html
 
-    def cross_metadata(self):
+    def cross_metadata(self) -> pd.DataFrame:
         """Load a dataframe containing metadata about samples in colony crosses,
         including which samples are parents or progeny in which crosses.
 
@@ -346,6 +346,14 @@ class Ag3(AnophelesDataResource):
         -------
         df : pandas.DataFrame
             A dataframe of sample metadata for colony crosses.
+
+        Examples
+        --------
+        Access cross metadata:
+
+            >>> import malariagen_data
+            >>> ag3 = malariagen_data.Ag3()
+            >>> df = ag3.cross_metadata()
 
         """
         debug = self._log.debug


### PR DESCRIPTION
## Description
This PR improves the documentation and typing for the `cross_metadata` method inside `Ag3`. Specifically it:
- Adds the `-> pd.DataFrame` return type hint to improve developer tooling/IDE support.
- Adds an `Examples` section to the numpy-style docstring demonstrating standard usage, bringing it up to parity with other public methods in the API.

## Changes Made
- Modified `malariagen_data/ag3.py`

## Testing
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are well documented