### PR TITLE
Fix Broken Image Links in Docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,7 +25,7 @@ API documentation
 
       *Anopheles funestus* subgroup.
 
-      .. image:: https://upload.wikimedia.org/wikipedia/commons/thumb/f/ff/Anopheles_Funetus.jpg/640px-Anopheles_Funetus.jpg
+      .. image:: https://upload.wikimedia.org/wikipedia/commons/thumb/f/ff/Anopheles_Funetus.jpg/500px-Anopheles_Funetus.jpg
 
    .. grid-item-card:: ``Amin1``
       :link: Amin1
@@ -33,7 +33,7 @@ API documentation
 
       *Anopheles minimus*.
 
-      .. image:: https://upload.wikimedia.org/wikipedia/commons/thumb/1/11/Anopheles_minimus_1.jpg/640px-Anopheles_minimus_1.jpg
+      .. image:: https://upload.wikimedia.org/wikipedia/commons/thumb/1/11/Anopheles_minimus_1.jpg/500px-Anopheles_minimus_1.jpg
 
    .. grid-item-card:: ``Adir1``
       :link: Adir1


### PR DESCRIPTION
- [ not applicable ]  Tests pass locally
- [ not applicable ]  Pre-commit hooks pass (or run pre-commit run --all-files)
- [ not applicable ]  Code is well-documented
- [x]  Commit messages are clear and descriptive

**What problem does this solve?**
Broken Links to wikimedia images in the docs

**How does it solve it?**
Replaced thumbnails widths with ones that are recommended by the wikimedia foundation other than those that were orginally used

Fixes #1228

**No breaking changes**
