### PR TITLE
Add input validation for dictionary -form region parameters in _parse_single_region and add mini-test to it

### DIFF
--- a/malariagen_data/util.py
+++ b/malariagen_data/util.py
@@ -680,6 +680,28 @@ def _parse_single_region(resource, region: single_region_param_type) -> Region:
 
     if isinstance(region, Region):
         # The region is already a Region, nothing to do.
+        contig=region.contig
+        start=region.start
+        end=region.end
+        
+        if contig is None:
+            raise ValueError("Region mapping must include 'contig'.")
+        
+        if contig not in _valid_contigs(resource):
+            raise ValueError(f"Unknown contig {contig!r}.")
+        
+        if start is not None:
+            if not isinstance(start, int) or start < 1:
+                raise ValueError(f"Invalid start position: {start!r}.")
+
+        if end is not None:   
+            if not isinstance(end, int) or end < 1 or end > resource.genome_sequence(region=contig).shape[0]:
+                raise ValueError(f"Invalid end position: {end!r}.")
+            
+        if start is not None and end is not None:    
+            if start > end:
+                raise ValueError(f"End position must be greater than start position.")
+        
         return region
 
     if isinstance(region, Mapping):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -23,6 +23,12 @@ def test_parse_region_contig(mock_resource):
     assert r.start is None
     assert r.end is None
 
+    r = _parse_single_region(mock_resource, Region("2L"))
+    assert r.contig == "2L"
+    assert r.start is None
+    assert r.end is None
+
+# String test
 def test_parse_region_interval(mock_resource):
     r = _parse_single_region(mock_resource, "2L:100-200")
     assert r.contig == "2L"
@@ -42,6 +48,7 @@ def test_parse_region_invalid_string(mock_resource):
         with pytest.raises(ValueError):
             _parse_single_region(mock_resource, region)
 
+# Mapping test
 def test_parse_region_invalid_dictionary(mock_resource):
     invalid_regions = [{}, 
                        {"start": 100, "end":200}, 
@@ -68,7 +75,42 @@ def test_parse_region_dictionary_only_end(mock_resource):
     assert r.contig == "2L"
     assert r.start is None
     assert r.end == 200
-            
+
+# Region instance test
+def test_parse_region_instance_interval(mock_resource):
+    r = _parse_single_region(mock_resource, Region("2L", start=100, end=200))
+    assert r.contig == "2L"
+    assert r.start == 100
+    assert r.end == 200
+
+def test_parse_region_instance_only_start(mock_resource):
+    r = _parse_single_region(mock_resource, Region("2L", start=200))
+    assert r.contig == "2L"
+    assert r.start == 200
+    assert r.end is None
+
+def test_parse_region_instance_only_end(mock_resource):
+    r = _parse_single_region(mock_resource, Region("2L", end=200))
+    assert r.contig == "2L"
+    assert r.start is None
+    assert r.end == 200
+
+def test_parse_region_invalid_instance(mock_resource):
+    invalid_regions = [Region(contig=""), 
+                       Region(contig="", start = 100, end = 200), 
+                       Region(contig="3L", start=-2, end=10), 
+                       Region(contig="X", start=10, end=-100), 
+                       Region(contig="2L", start=100, end=10), 
+                       Region(contig= "Invalid_contig", start=10, end=20), 
+                       Region(contig="2L", start="abc", end=10), 
+                       Region(contig="2R", start=100, end="bcd")
+                       ]
+    
+    for region in invalid_regions:
+        with pytest.raises(ValueError):
+            _parse_single_region(mock_resource, region)
+
+# Region type test
 def test_parse_region_invalid_type(mock_resource):
     invalid_types = [123456, ["2L:100-230"], ("2L:100-250",), True, False, 3.154]
     for types in invalid_types:


### PR DESCRIPTION
## Summary
This PR adds input validation for the 'Mapping' code path in '_parse_single_region'. In the previous code, there was no problem only if the inputs were perfectly safe. However, there was no input validation; malformed dictionary inputs can be silently accepted and would cause issues later. This change makes the function fail fast with a clear, actionable error message at the point of entry. 

## Problem 
The following malformed inputs can be silently accepted:
1. Missing contig: {"start":100, "end":200}
2. Invalid contig name: {"contig": "Invalid_name", "start':100, "end":200}
3. Negative coordinate or end > start:  {"contig": "2L", "start':-100, "end":200} or  {"contig": "2L", "start':100, "end": 20}
4. Ending coordinate is greater than the length of the genome sequence.
Therefore, I thought that input validation for the 'Mapping' is useful.

## Solution
Added the following validation in the 'isinstance(region, Mapping)' branch:
1. 'contig' is required - raises ValueError if missing
2. 'contig' must be valid - checked against '_valid_contigs(resource)' as same as how string regions are validated in '_handle_region_coords'
3. Coordinates must be positive integers - checked as same as in '_handle_region_coords'
4. 'start' must not exceed 'end' - consistent with the existing check in 
   `_handle_region_coords`
5. 'end' must be less than the length of the sequence
Additionally added a docstring to clarify expected input structure and validation behavior.

## Effect
1. Fully backward compatible for valid inputs.
2. No existing tests are broken.
3. Just added validation for inputs that were already broken to prevent silent acceptance of malformed inputs.

## Testing
New tests were added in 'tests/test_util.py' with pytest by covering:
- Valid whole-contig dict region
- Valid interval dict region (only end, only start coordinates are accepted)
- 8 invalid dict cases each raising `ValueError`
- Invalid string region cases
- Invalid type cases raising `TypeError`

All tests passed when I ran it with poetry: poetry run pytest tests/test_util.py -v