### PR TITLE
Fix Adar1 repr doc links pointing to Adir1 (copy-paste error)

### DIFF
--- a/malariagen_data/adar1.py
+++ b/malariagen_data/adar1.py
@@ -152,7 +152,7 @@ class Adar1(AnophelesDataResource):
             f"Please note that data are subject to terms of use,\n"
             f"for more information see https://www.malariagen.net/data\n"
             f"or contact support@malariagen.net. For API documentation see \n"
-            f"https://malariagen.github.io/malariagen-data-python/v{malariagen_data.__version__}/Adir1.html"
+            f"https://malariagen.github.io/malariagen-data-python/v{malariagen_data.__version__}/Adar1.html"
         )
         return text
 
@@ -167,7 +167,7 @@ class Adar1(AnophelesDataResource):
                         Please note that data are subject to terms of use,
                         for more information see <a href="https://www.malariagen.net/data">
                         the MalariaGEN website</a> or contact support@malariagen.net.
-                        See also the <a href="https://malariagen.github.io/malariagen-data-python/v{malariagen_data.__version__}/Adir1.html">Adir1 API docs</a>.
+                        See also the <a href="https://malariagen.github.io/malariagen-data-python/v{malariagen_data.__version__}/Adar1.html">Adar1 API docs</a>.
                     </td></tr>
                 </thead>
                 <tbody>


### PR DESCRIPTION
## What

Fixes `__repr__` and `_repr_html_` in `Adar1` — both documentation links incorrectly point to `Adir1.html` instead of `Adar1.html`.

## Why

Copy-paste error from when `adar1.py` was created using `adir1.py` as a template (see commit ccc65928). The doc URL and link text were never updated to reference the correct species.

## Changes

- **Line 155** (`__repr__`): `Adir1.html` → `Adar1.html`
- **Line 170** (`_repr_html_`): `Adir1.html` → `Adar1.html` and `Adir1 API docs` → `Adar1 API docs`

## Impact

Users calling `repr()` on an `Adar1` instance or viewing it in a Jupyter notebook are currently directed to the wrong API documentation page.