### PR TITLE
Add helper function for summarizing sample metadata

### DIFF
--- a/malariagen_data/anoph/sample_metadata.py
+++ b/malariagen_data/anoph/sample_metadata.py
@@ -908,6 +908,16 @@ class AnophelesSampleMetadata(AnophelesBase):
         )
 
         return df_pivot
+    
+    def sample_metadata_summary(self):
+        
+        df = self.sample_metadata()
+
+        return {
+            "total_samples": len(df),
+            "countries": sorted(df["country"].dropna().unique().tolist()),
+            "species_distribution": df["taxon"].value_counts().to_dict()
+        }
 
     @_check_types
     @doc(
@@ -1907,3 +1917,4 @@ def _locate_cohorts(*, cohorts, data, min_cohort_size):
         )
 
     return coh_dict
+


### PR DESCRIPTION
This PR adds a helper function `sample_metadata_summary()` to provide a quick overview of sample metadata.

The function returns:
- total number of samples
- list of countries
- species distribution

This improves usability by allowing users to quickly inspect dataset characteristics without additional processing.

The implementation is simple and does not modify any existing functionality.