### PR TITLE
Improve version test to enforce valid format

### DIFF
--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -2,9 +2,14 @@ from packaging.version import Version, parse
 
 import malariagen_data
 
-
 def test_version():
     assert hasattr(malariagen_data, "__version__")
-    assert isinstance(malariagen_data.__version__, str)
-    version = parse(malariagen_data.__version__)
+    version_str = malariagen_data.__version__
+
+    assert isinstance(version_str, str)
+    assert version_str != ""
+
+    version = parse(version_str)
+
     assert isinstance(version, Version)
+    assert str(version) == version_str  # normalized format


### PR DESCRIPTION
This PR strengthens the test_version check by:

Ensuring __version__ exists and is not empty
Validating it follows proper version format (PEP 440)
Adding a normalization check to avoid malformed versions
Helps prevent invalid version strings
Improves package reliability and consistency