### PR TITLE
fix: raise ValueError on empty CNV HMM data instead of IndexError

### DIFF
--- a/malariagen_data/anoph/cnv_data.py
+++ b/malariagen_data/anoph/cnv_data.py
@@ -745,6 +745,11 @@ class AnophelesCnvData(
         debug("remove data where HMM is not called")
         data = data.query("call_CN >= 0")
 
+        if len(data) == 0:
+            raise ValueError(
+                f"No CNV HMM data found for sample {sample_id!r} in region {region_prepped!r}."
+            )
+
         debug("set up y range")
         if y_max == "auto":
             y_max_float = data["call_CN"].max() + 2
@@ -929,6 +934,11 @@ class AnophelesCnvData(
         start = ds_cnv["variant_position"].values
         end = ds_cnv["variant_end"].values
         n_windows, n_samples = cn.shape
+
+        if n_windows == 0:
+            raise ValueError(
+                f"No CNV HMM data found for region {region_prepped!r}."
+            )
 
         debug("figure out X axis limits from data")
         x_min = start[0]


### PR DESCRIPTION
## Problem

Two plotting functions in `cnv_data.py` crash with a cryptic
`IndexError: index 0 is out of bounds for axis 0 with size 0`
when a requested region or sample has no valid CNV HMM data:

- `plot_cnv_hmm_coverage` — after `data.query("call_CN >= 0")` filters
  out all uncalled windows, accessing `values[0]` / `values[-1]` on the
  empty DataFrame crashes.
- `plot_cnv_hmm_heatmap_track` — if `n_windows == 0` for the requested
  region, accessing `start[0]` and `end[-1]` crashes.

## Fix

Added an early `ValueError` guard in both functions before the unsafe
index access, with a descriptive message that names the sample/region
so the user knows exactly what produced no data.

Follows the existing pattern used in `frq_base.py` and elsewhere in
the codebase.

## Files Changed

- `malariagen_data/anoph/cnv_data.py`
