### PR TITLE
fix: raise ValueError when iHS/XP-EHH arrays are empty after filtering

### DIFF
--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -970,6 +970,12 @@ class AnophelesDataResource(
             inline_array=inline_array,
         )
 
+        if len(x) == 0:
+            raise ValueError(
+                "No iHS values remain after filtering. "
+                "Try relaxing filter_min_maf or min_ehh parameters."
+            )
+
         # determine X axis range
         x_min = x[0]
         x_max = x[-1]
@@ -1493,6 +1499,12 @@ class AnophelesDataResource(
             chunks=chunks,
             inline_array=inline_array,
         )
+
+        if len(x) == 0:
+            raise ValueError(
+                "No XP-EHH values remain after filtering. "
+                "Try relaxing filter_min_maf or min_ehh parameters."
+            )
 
         # determine X axis range
         x_min = x[0]


### PR DESCRIPTION
## SUMMARY

This PR improves error handling in GWSS plotting by avoiding crashes when all iHS or XP-EHH values are filtered out. Instead of a confusing `IndexError`, users now get a clear `ValueError` with guidance.
Changes are in `malariagen_data/anopheles.py` (`plot_ihs_gwss_track`, `plot_xpehh_gwss_track`).

---

## FIX


**Before**

```python
x_min = x[0]
x_max = x[-1]
```

**After**

```python
if len(x) == 0:
    raise ValueError(
        "No iHS values remain after filtering. "
        "Try relaxing filter_min_maf or min_ehh parameters."
    )

x_min = x[0]
x_max = x[-1]
```
---

## VERIFICATION

Using strict filters or a small region previously caused a crash with `IndexError`.
Now it raises a clear `ValueError` explaining what happened and how to fix it.
Normal runs are unchanged.
