### PR TITLE
Fix #1308: Remove dead dask.config.set() at module import time

### DIFF
--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -1,13 +1,9 @@
 import sys
 
-import dask
 import pandas as pd  # type: ignore
 import plotly.express as px  # type: ignore
 import malariagen_data
 from .anopheles import AnophelesDataResource
-
-# silence dask performance warnings
-dask.config.set(**{"array.slicing.split_native_chunks": False})  # type: ignore
 
 MAJOR_VERSION_NUMBER = 3
 MAJOR_VERSION_PATH = "v3"


### PR DESCRIPTION
Closes #1308.

## Summary

`ag3.py:10` executed the following at **module import time**:

```python
# silence dask performance warnings
dask.config.set(**{"array.slicing.split_native_chunks": False})
```

This line was added in an older dask era to silence a `PerformanceWarning` emitted by certain slicing operations. On current dask it is dead code — removing it directly fixes the bug (`import malariagen_data` no longer mutates global dask configuration).

## Why just remove the line

Verified empirically on dask `2025.11.0` (what the project resolves to since `dask = "*"` in `pyproject.toml`):

- `dask.config.get("array.slicing.split_native_chunks", "DEFAULT")` returns `"DEFAULT"` — the config key is no longer recognised.
- `from dask.array.slicing import PerformanceWarning` raises `ImportError` — the warning class has been removed.
- `da.take` / `da.compress` / fancy indexing with out-of-order indices emit **zero warnings** with the config set to `True`, `False`, or unset.

So the line suppresses a warning that no longer exists, gated by a config key that no longer exists. Scoping it to context managers (the previous approach in this PR) preserved dead code unnecessarily; deleting it is the cleaner fix.

## Diff

1 file changed, 4 deletions.

```diff
-import dask
 import pandas as pd
 ...
-# silence dask performance warnings
-dask.config.set(**{"array.slicing.split_native_chunks": False})
```

## Test plan

- [x] `python -c "import malariagen_data; import dask; assert dask.config.get('array.slicing.split_native_chunks', 'DEFAULT') == 'DEFAULT'"` — passes (import no longer mutates dask config).
- [x] `pytest tests/anoph/test_snp_data.py` — 193 passed, no `PerformanceWarning` emitted.
- [x] `pytest tests/anoph/test_frq.py tests/anoph/test_cnv_data.py tests/anoph/test_hapclust.py tests/anoph/test_dipclust.py tests/anoph/test_hap_data.py tests/anoph/test_aim_data.py` — 133 passed.
- [x] `pre-commit run --files malariagen_data/ag3.py` — ruff, ruff-format, trailing-whitespace, end-of-file all pass.
- [x] `mypy malariagen_data/ag3.py` — no issues.
- [ ] CI matrix on PR (linting, coverage, tests across Python 3.10 / 3.11 / 3.12 × numpy `==2.0.2` and `>=2.0.2,<2.1`).

## Backwards compatibility

- No public API changed.
- If anyone pins a very old dask version where the warning still fires, they may see it again; the project does not currently pin a minimum dask version in `pyproject.toml` (`dask = "*"`), so modern dask is the supported target.
