### PR TITLE
Surface ipinfo.io location check failures (closes #1311)

### DIFF
--- a/malariagen_data/anoph/base.py
+++ b/malariagen_data/anoph/base.py
@@ -103,8 +103,16 @@ class AnophelesBase:
         if check_location:
             try:
                 self._client_details = ipinfo.getHandler().getDetails()
-            except OSError:
-                pass
+            except OSError as exc:
+                self._log.debug(f"Location check failed: {exc}")
+                warnings.warn(
+                    "Could not determine client location via ipinfo.io "
+                    f"({exc}). Region-optimal GCS bucket selection is "
+                    "unavailable. You can manually specify a region using "
+                    "the `url` parameter.",
+                    UserWarning,
+                    stacklevel=2,
+                )
 
         # Determine cloud location details.
         self._gcp_region = _get_gcp_region(self._client_details)


### PR DESCRIPTION
## Summary

Closes #1311.

The `ipinfo.io` lookup performed in `AnophelesBase.__init__` swallowed every `OSError` silently, leaving `_client_details = None`. That cascaded into `_get_gcp_region()` returning `None`, which in turn caused the GCS URL optimisation (selecting a region-local bucket) to fall back to the default bucket — without any indication that the location check had failed.

The failure mode was indistinguishable from a successful lookup that returned no location data, which is exactly the situation #1311 describes.

## Why it matters

- **Performance:** Researchers near a GCS region (e.g. `us-central1`) could unknowingly pull multi-GB datasets from a distant bucket.
- **Debuggability:** Slow-download reports had nothing in the application state or logs to correlate with a failed `ipinfo.io` lookup.
- **Prevalence:** The networks most likely to block external lookups (corporate firewalls, institutional VPNs, restricted regions) are exactly the environments where many researchers operate.

## Change

`malariagen_data/anoph/base.py`, lines 100–105.

Before:

\`\`\`python
self._client_details = None
if check_location:
    try:
        self._client_details = ipinfo.getHandler().getDetails()
    except OSError:
        pass
\`\`\`

After:

\`\`\`python
self._client_details = None
if check_location:
    try:
        self._client_details = ipinfo.getHandler().getDetails()
    except OSError as exc:
        self._log.debug(f"Location check failed: {exc}")
        warnings.warn(
            "Could not determine client location via ipinfo.io "
            f"({exc}). Region-optimal GCS bucket selection is "
            "unavailable. You can manually specify a region using "
            "the \`url\` parameter.",
            UserWarning,
            stacklevel=2,
        )
\`\`\`

The fallback behaviour itself is unchanged; the fix is purely additive.

- `self._log.debug(...)` captures the underlying exception for users running with `debug=True`.
- `warnings.warn(..., UserWarning, stacklevel=2)` surfaces the failure to end users with an actionable hint about the `url` override, without being intrusive in the common success path.
- `warnings` is already imported at the top of the module; `self._log` is initialised on the line immediately preceding this block, so the warning is safe to emit in `__init__`.

## Test plan

- [x] `pre-commit run --files malariagen_data/anoph/base.py` — passed (ruff, ruff-format, trailing-whitespace, end-of-file)
- [x] `poetry run mypy malariagen_data/anoph/base.py` — passed (no issues)
- [x] `poetry run pytest tests/anoph/test_base.py` — 44 passed
- [ ] CI matrix on PR (linting, coverage, tests across Python 3.10/3.11/3.12 × numpy 2.0.2 / >=2.0.2,<2.1)

## Backwards compatibility

No public API changes. No change to fallback behaviour. The only observable difference is a `UserWarning` (and a DEBUG log entry when `debug=True`) when the `ipinfo.io` lookup fails, which previously produced no signal at all.