### PR TITLE
Add stacklevel 2

### DIFF
--- a/malariagen_data/anoph/cnv_data.py
+++ b/malariagen_data/anoph/cnv_data.py
@@ -626,6 +626,7 @@ class AnophelesCnvData(
             warnings.warn(
                 "Parameter 'contig' is deprecated; use 'contigs' instead.",
                 DeprecationWarning,
+                stacklevel=2,
             )
             contigs = contig
 

--- a/malariagen_data/anoph/sample_metadata.py
+++ b/malariagen_data/anoph/sample_metadata.py
@@ -400,6 +400,7 @@ class AnophelesSampleMetadata(AnophelesBase):
                 warnings.warn(
                     f"WARNING: The surveillance flags data contains null values for sample set {sample_set}",
                     UserWarning,
+                    stacklevel=2,
                 )
 
                 # Restore the original warning filters.
@@ -419,6 +420,7 @@ class AnophelesSampleMetadata(AnophelesBase):
             warnings.warn(
                 f"WARNING: The surveillance flags data is missing for sample set {sample_set}",
                 UserWarning,
+                stacklevel=2,
             )
 
             # Restore the original warning filters.


### PR DESCRIPTION
Fixes #1317 
Add missing `stacklevel=2` to `warnings.warn()` calls in `sample_metadata.py` and `cnv_data.py`.