### PR TITLE
Correct NumPy version in CONTRIBUTING.md CI note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,7 +234,7 @@ poetry run pytest -v tests --typeguard-packages=malariagen_data,malariagen_data.
 ### Review process
 
 - PRs require approval from a project maintainer
-- CI tests must pass (pytest on Python 3.10 with NumPy 1.26.4)
+- CI tests must pass (pytest on Python 3.10 with NumPy 2.0.2)
 - Address review feedback by pushing new commits to your branch
 - Once approved, a maintainer will merge your PR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,7 +234,7 @@ poetry run pytest -v tests --typeguard-packages=malariagen_data,malariagen_data.
 ### Review process
 
 - PRs require approval from a project maintainer
-- CI tests must pass (pytest on Python 3.10 with NumPy 2.0.2)
+- All required CI checks must pass: the test matrix (Python 3.10, 3.11, and 3.12, each against the pinned and the latest supported NumPy), plus linting and coverage.
 - Address review feedback by pushing new commits to your branch
 - Once approved, a maintainer will merge your PR
 


### PR DESCRIPTION
CONTRIBUTING.md stated that CI tests run on Python 3.10 with NumPy 1.26.4. The Matrix in test.yml pins numpy >= 2.0.2 < 2.1, so the note was out of date. Also opened as a second PR while still a first-time contributor, to test whether the workflow approval issue Jon hit on #1346 recurs.